### PR TITLE
fix workflow-service urls, add formatting

### DIFF
--- a/deploy.rb
+++ b/deploy.rb
@@ -109,5 +109,8 @@ repo_infos.each do |repo_info|
   end
 end
 
+puts "\n\n------- BUNDLE AUDIT REPORT, AFTER DEPLOY -------"
 auditor.report unless ssh_check
+
+puts "\n\n------- STATUS CHECK RESULTS, AFTER DEPLOY -------"
 deploys.each { |repo, success| puts "#{repo} => #{success ? 'success' : 'failed'}" } unless ssh_check

--- a/repos.yml
+++ b/repos.yml
@@ -111,6 +111,6 @@ status:
 ---
 repo: sul-dlss/workflow-server-rails
 status:
-  qa: https://sul-lyberservices-qa.stanford.edu/workflow/status
-  stage: https://sul-lyberservices-test.stanford.edu/workflow/status
-  prod: https://sul-lyberservices-prod.stanford.edu/workflow/status
+  qa: https://workflow-service-qa.stanford.edu/workflow/status
+  stage: https://workflow-service-stage.stanford.edu/workflow/status
+  prod: https://workflow-service-prod.stanford.edu/workflow/status


### PR DESCRIPTION
## Why was this change made?

- fix workflow-server-rails urls (d'oh)
- add a little separation and clarity to the reports printed at the end of a deploy

## How was this change tested?

I waved my hands.

## Which documentation and/or configurations were updated?

n/a
