### PR TITLE
run bundle before bundle audit

### DIFF
--- a/lib/auditor.rb
+++ b/lib/auditor.rb
@@ -10,6 +10,7 @@ class Auditor
 
   def audit(dir:, repo:)
     Dir.chdir(dir) do
+      out, status = Open3.capture2 'bundle'
       out, status = Open3.capture2 'bundle exec bundle audit'
       return if status.success?
 


### PR DESCRIPTION
## Why was this change made?

Because script was complaining about missing gems for repos it wasn't even deploying.

## How was this change tested?

I ran the script with the change.

## Which documentation and/or configurations were updated?

n/a

