### PR TITLE
more accurate messaging for --checkssh usage

### DIFF
--- a/deploy.rb
+++ b/deploy.rb
@@ -94,11 +94,13 @@ repo_infos.each do |repo_info|
   update_or_create_repo(repo_dir, repo)
   auditor.audit(repo: repo, dir: repo_dir) unless ssh_check
   Dir.chdir(repo_dir) do
-    puts "Deploying #{repo_dir}"
+    puts "Installing gems for #{repo_dir}"
     `bundle install`
     if ssh_check
+      puts "running 'cap #{stage} ssh_check' for #{repo_dir}"
       `bundle exec cap #{stage} ssh_check`
     else
+      puts "Deploying #{repo_dir}"
       comment_out_branch_prompt!
       deploys[repo] = deploy(stage)
       status_url = repo_info.fetch('status', {})[stage]


### PR DESCRIPTION
figured it was something like this, but i was definitely nervous for a moment that i'd forgotten the `--checkssh` flag when i saw `Deploying tmp/repos/sul-dlss/dor_indexing_app` flash by on my terminal when i glanced back at it.

i included the `ssh_check` message because as it is, all you get is `Pseudo-terminal will not be allocated because stdin is not a terminal.` for each host.  a bit more inline info seemed like it'd be nice.

## Why was this change made?

blood pressure reduction

## How was this change tested?

ran `./deploy.rb stage --checkssh` from my laptop (haven't yet gotten to deploying, need to investigate some failing dependency updates to allow merging to happen)

## Which documentation and/or configurations were updated?

n/a