### PR TITLE
output touchups

### DIFF
--- a/deploy.rb
+++ b/deploy.rb
@@ -68,6 +68,10 @@ def repo_infos
   YAML.load_stream(File.open('repos.yml'))
 end
 
+def repo_names
+  repo_infos.map { |repo_info| repo_info['repo'] }
+end
+
 # Comment out where we ask what branch to deploy. We always deploy master.
 def comment_out_branch_prompt!
   text = File.read('config/deploy.rb')
@@ -87,6 +91,8 @@ ssh_check = ARGV[1] == '--checkssh'
 
 auditor = Auditor.new
 
+puts "repos to #{ssh_check ? 'ssh_check' : 'deploy'}: #{repo_names.join(', ')}"
+
 deploys = {}
 repo_infos.each do |repo_info|
   repo = repo_info['repo']
@@ -100,13 +106,14 @@ repo_infos.each do |repo_info|
       puts "running 'cap #{stage} ssh_check' for #{repo_dir}"
       `bundle exec cap #{stage} ssh_check`
     else
-      puts "Deploying #{repo_dir}"
+      puts "###\nDeploying #{repo_dir}..."
       comment_out_branch_prompt!
-      deploys[repo] = deploy(stage)
+      deploys[repo] = { cap_result: deploy(stage) }
+      puts "...Deployed #{repo_dir}; result: #{deploys[repo]}\n###"
       status_url = repo_info.fetch('status', {})[stage]
-      next unless deploys[repo] && status_url
+      next unless deploys[repo][:cap_result] && status_url
 
-      deploys[repo] = status_check(status_url)
+      deploys[repo].merge!({ status_check_result: status_check(status_url) })
     end
   end
 end
@@ -116,6 +123,17 @@ unless ssh_check
   auditor.report
 
   puts "\n\n------- STATUS CHECK (https::/xxx/status) RESULTS AFTER DEPLOY -------\n"
-  deploys.each { |repo, success| puts "#{repo} => #{success ? 'success' : 'FAILED'}" }
+  deploys.each do |repo, deploy_result|
+    cap_result = deploy_result[:cap_result] ? 'success' : 'FAILED'
+    status_check_result = case deploy_result[:status_check_result]
+      when nil
+        'N/A'
+      when true
+        'success'
+      else
+        'FAILED'
+      end
+    puts "#{repo}\n => 'cap #{stage} deploy' result: #{cap_result}\n => status check result:      #{status_check_result}"
+  end
   puts "\n------- END STATUS CHECK RESULTS -------\n"
 end


### PR DESCRIPTION
* at the start of the run, list repo names for which deployment or ssh_check is to happen
* log line and ### delimiter before and after each deploy, for easier visual skimming and text searching to find specific deployment output
* include both cap deploy result and status check result in final output, with a bit more nuance on the status check output

## Why was this change made?

easier to determine deployment results at a glance, and whether issues are due to cap deployment or status URL check.

## How was this change tested?

i ran both `--checkssh` mode and a regular deployment against both qa and stage.

## Which documentation and/or configurations were updated?

none, changes should hopefully just clarify output


## screenshots

![Screen Shot 2020-07-16 at 6 28 54 PM](https://user-images.githubusercontent.com/7741604/87738776-010d7300-c793-11ea-90c2-ccfed63eefa5.png)
![Screen Shot 2020-07-16 at 6 34 04 PM](https://user-images.githubusercontent.com/7741604/87738786-04a0fa00-c793-11ea-8aea-f69718a2c507.png)

