### PR TITLE
Bundler audit is not required by this project

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ Install required gems:
 
 ```shell
 $ gem install byebug
-$ gem install bundler-audit
 ```
 
 ## Usage


### PR DESCRIPTION


## Why was this change made?
It's only required in the projects that are being deployed (e.g. argo, hydrus, preassembly, etc)


## How was this change tested?

```ruby
LOAD_PATH.unshift File.expand_path('lib', __dir__)
require 'auditor'
=> true
auditor = Auditor.new
auditor.audit(repo: 'argo', dir: 'tmp/repos/sul-dlss/argo')
=> nil
auditor.report
=> nil
```

## Which documentation and/or configurations were updated?
Readme


