### PR TITLE
correct workflow-server-rails status URLs

### DIFF
--- a/repos.yml
+++ b/repos.yml
@@ -108,6 +108,6 @@ repo: sul-dlss/was_robot_suite
 ---
 repo: sul-dlss/workflow-server-rails
 status:
-  qa: https://workflow-service-qa.stanford.edu/workflow/status
-  stage: https://workflow-service-stage.stanford.edu/workflow/status
-  prod: https://workflow-service-prod.stanford.edu/workflow/status
+  qa: https://workflow-service-qa.stanford.edu/status
+  stage: https://workflow-service-stage.stanford.edu/status
+  prod: https://workflow-service-prod.stanford.edu/status


### PR DESCRIPTION
per comment from @jcoyne on a related ops tasks ticket

## Why was this change made?

to fix the status URLs we hit for the workflow-server-rails app

## How was this change tested?

`curl` from the preservation VMs, since those can reach the workflow-server-rails app (at present, we can't reach it from laptops, even on VPN, per the ops ticket that spawned this).

## Which documentation and/or configurations were updated?

this is a config only update