### PR TITLE
update status checks for sul-pub and workflow-server-rails

### DIFF
--- a/repos.yml
+++ b/repos.yml
@@ -70,8 +70,9 @@ status:
 repo: sul-dlss/sul_pub
   # qa deploy target isn't set up normally
 status:
-  # qa: https://sul-pub-qa.stanford.edu/status/all/
-  stage: https://sul-pub-stage.stanford.edu/status/all/
+  # if you check all on sul-pub stage, it will record a fail because harvesting is disabled there, that is expected
+  # qa: https://sul-pub-cap-qa.stanford.edu/status/all/
+  stage: https://sul-pub-stage.stanford.edu/status/
   prod: https://sul-pub-prod.stanford.edu/status/all/
 ---
 repo: sul-dlss/suri-rails
@@ -104,7 +105,8 @@ repo: sul-dlss/was_robot_suite
 ---
 repo: sul-dlss/workflow-server-rails
 status:
-  qa: https://workflow-service-qa.stanford.edu/status/all/
-  stage: https://workflow-service-stage.stanford.edu/status/all/
-  # prod is locked down and cannot be checked remotely
+  # workflow-server-rails is locked down on all environments and cannot be checked remotely
+  # you can check manually using curl from the corresponding argo vms
+  # qa: https://workflow-service-qa.stanford.edu/status/all/
+  # stage: https://workflow-service-stage.stanford.edu/status/all/
   # prod: https://workflow-service-prod.stanford.edu/status/all/


### PR DESCRIPTION
## Why was this change made?

- small tweak to the (currently unused) health check URL for the non-standard sul_pub qa environment to make it match the actual VM name
- adjust the sul_pub stage health check to not do an "all" check, because harvesting of publication is turned off in stage on purpose and this will cause one of the health checks to fail there
- workflow-server-rails stage and qa now appear to be locked down, making us unable to do a health check across any environments from our laptops

## How was this change tested?



## Which documentation and/or configurations were updated?



