### PR TITLE
comment out all status checks for workflow-server-rails to avoid error

### DIFF
--- a/repos.yml
+++ b/repos.yml
@@ -104,9 +104,8 @@ status:
 repo: sul-dlss/was_robot_suite
 ---
 repo: sul-dlss/workflow-server-rails
-status:
-  # workflow-server-rails is locked down on all environments and cannot be checked remotely
-  # you can check manually using curl from the corresponding argo vms
-  # qa: https://workflow-service-qa.stanford.edu/status/all/
-  # stage: https://workflow-service-stage.stanford.edu/status/all/
-  # prod: https://workflow-service-prod.stanford.edu/status/all/
+# workflow-server-rails is locked down on all environments and status cannot be checked remotely
+# you can check manually using curl from the corresponding argo vms
+# qa: https://workflow-service-qa.stanford.edu/status/all/
+# stage: https://workflow-service-stage.stanford.edu/status/all/
+# prod: https://workflow-service-prod.stanford.edu/status/all/


### PR DESCRIPTION
## Why was this change made?

Got this error at the tail end of the deploys, I think this will fix it by not having a nil `status` block when we do not have any URLs to check:

```
Traceback (most recent call last):
	4: from ./deploy.rb:96:in `<main>'
	3: from ./deploy.rb:96:in `each'
	2: from ./deploy.rb:101:in `block in <main>'
	1: from ./deploy.rb:101:in `chdir'
./deploy.rb:112:in `block (2 levels) in <main>': undefined method `[]' for nil:NilClass (NoMethodError)
```

## How was this change tested?



## Which documentation and/or configurations were updated?



