### PR TITLE
was-thumbnail-service has been decommissioned

### DIFF
--- a/repos.yml
+++ b/repos.yml
@@ -95,12 +95,6 @@ status:
   stage: https://was-registrar-app-stage.stanford.edu/status/all/
   prod: https://was-registrar-app.stanford.edu/status/all/
 ---
-repo: sul-dlss/was-thumbnail-service
-# has no qa deploy target, but repo is going away
-status:
-  stage: https://was-thumbnail-stage.stanford.edu/status/all/
-  prod: https://was-thumbnail-prod.stanford.edu/status/all/
----
 repo: sul-dlss/was_robot_suite
 ---
 repo: sul-dlss/workflow-server-rails


### PR DESCRIPTION
## Why was this change made?

server has been decommissioned, can no longer connect or deploy to it.

see https://github.com/sul-dlss/was-thumbnail-service/issues/211

## How was this change tested?

ran with the `--checkssh` flag against stage, currently running weekly dep updates against stage

## Which documentation and/or configurations were updated?

n/a