### PR TITLE
Add happy-heron (h2) to deploy repos

### DIFF
--- a/repos.yml
+++ b/repos.yml
@@ -29,6 +29,12 @@ status:
   stage: https://sul-gbooks-stage.stanford.edu/status/all/
   prod: https://sul-gbooks-prod.stanford.edu/status/all/
 ---
+repo: sul-dlss/happy-heron
+status:
+  qa: https://sul-h2-qa.stanford.edu/status/all/
+  stage: https://sul-h2-stage.stanford.edu/status/all/
+  prod: https://sul-h2-prod.stanford.edu/status/all/
+---
 repo: sul-dlss/hydra_etd
 status:
   qa: https://etd-qa.stanford.edu/status/all/


### PR DESCRIPTION
Fixes sul-dlss/happy-heron#10

Currently blocked by https://github.com/sul-dlss/happy-heron/issues/11 but should be ready soon. Will undraft once that's merged.

## Why was this change made?

To add H2 to the list of deployed projects.

## How was this change tested?

It will be tested by future FRs.

## Which documentation and/or configurations were updated?

`repos.yml`

