### PR TITLE
Ask git for the default branch

### DIFF
--- a/deploy.rb
+++ b/deploy.rb
@@ -18,7 +18,7 @@ WORK_DIR = ['tmp/repos'].freeze
 def update_repo(repo_dir)
   Dir.chdir(repo_dir) do
     `git checkout config/deploy.rb`
-    `git checkout master 2> /dev/null && git pull`
+    `git checkout $(git symbolic-ref refs/remotes/origin/HEAD) 2> /dev/null && git pull`
   end
 end
 
@@ -71,7 +71,7 @@ def repo_names
   repo_infos.map { |repo_info| repo_info['repo'] }
 end
 
-# Comment out where we ask what branch to deploy. We always deploy master.
+# Comment out where we ask what branch to deploy. We always deploy to the default branch (master for most, main for some)
 def comment_out_branch_prompt!
   text = File.read('config/deploy.rb')
   text.gsub!(/(?=ask :branch)/, '# ')

--- a/deploy.rb
+++ b/deploy.rb
@@ -17,8 +17,8 @@ WORK_DIR = ['tmp/repos'].freeze
 
 def update_repo(repo_dir)
   Dir.chdir(repo_dir) do
-    `git checkout config/deploy.rb`
-    `git checkout $(git symbolic-ref refs/remotes/origin/HEAD) 2> /dev/null && git pull`
+    `git fetch origin`
+    `git reset --hard $(git symbolic-ref refs/remotes/origin/HEAD) 2> /dev/null`
   end
 end
 


### PR DESCRIPTION
Instead of hard-coding `master`. This is the approach we're using successfully in access-update-scripts.

## Why was this change made?



## How was this change tested?



## Which documentation and/or configurations were updated?



