### PR TITLE
allow primary branch name to be configurable per repo

### DIFF
--- a/repos.yml
+++ b/repos.yml
@@ -30,6 +30,7 @@ status:
   prod: https://sul-gbooks-prod.stanford.edu/status/all/
 ---
 repo: sul-dlss/happy-heron
+branch_name: main
 status:
   qa: https://sul-h2-qa.stanford.edu/status/all/
   stage: https://sul-h2-stage.stanford.edu/status/all/


### PR DESCRIPTION
## Why was this change made?

Some projects use 'main' instead of 'master'.  This allows us to configure those repos to use that branch, defaulting to master if not set.

## How was this change tested?



## Which documentation and/or configurations were updated?



