### PR TITLE
use pres-cat-2 for checks since one check always fails on -1 by design

### DIFF
--- a/repos.yml
+++ b/repos.yml
@@ -59,7 +59,9 @@ repo: sul-dlss/preservation_catalog
 status:
   qa: https://preservation-catalog-qa-01.stanford.edu/status/all/
   stage: https://preservation-catalog-stage-01.stanford.edu/status/all/
-  prod: https://preservation-catalog-prod-01.stanford.edu/status/all/
+  prod: https://preservation-catalog-prod-02.stanford.edu/status/all/
+  # note that the https://preservation-catalog-prod-01.stanford.edu/status/all box status check fails the 
+  #  feature-zip_storage_dir: PASSED Directory '/sdr-transfers' is writable  check, but the 2 passes by design
 ---
 repo: sul-dlss/preservation_robots
 ---


### PR DESCRIPTION
## Why was this change made?

preservation_catalog-01 fails a status check by design, but the check works on preservation-catalog-02, let's hit that instead

## How was this change tested?



## Which documentation and/or configurations were updated?



