### PR TITLE
Create a report of which versions of cocina-models are the the lockfiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,16 @@ Make sure that:
 * You have previously `ssh`-ed into all servers.
   * NOTE: If you are unsure about this, run `./deploy.rb [qa|stage|prod] --checkssh` and watch the output for any errors!
 
-NOTE: if you prefer your output in color, this will work:
+### Check versions of cocina
 
 ```
-export SSHKIT_COLOR='TRUE'
+./deploy.rb qa --check-cocina
 ```
 
-Run the deploys
+This will let you know which versions of cocina each project is locked to.
+
+
+### Run the deploys
 
 ```
 ./deploy.rb qa   # or stage or prod
@@ -27,3 +30,7 @@ Run the deploys
 Note:
 * All repos will be cloned to `tmp`.
 * To skip a repo, comment it out in `repos.yml`.
+* if you prefer your output in color, this will work:
+```
+export SSHKIT_COLOR='TRUE'
+```


### PR DESCRIPTION
This prevents you from deploying incompatible releases:

```
13:27 $ ./deploy.rb qa --check-cocina
repos to deploy: sul-dlss/argo, sul-dlss/common-accessioning, sul-dlss/dor-services-app, sul-dlss/dor_indexing_app, sul-dlss/gis-robot-suite, sul-dlss/google-books, sul-dlss/happy-heron, sul-dlss/hydra_etd, sul-dlss/hydrus, sul-dlss/modsulator-app-rails, sul-dlss/pre-assembly, sul-dlss/preservation_catalog, sul-dlss/preservation_robots, sul-dlss/robot-console, sul-dlss/sdr-api, sul-dlss/sul_pub, sul-dlss/suri-rails, sul-dlss/technical-metadata-service, sul-dlss/was-registrar-app, sul-dlss/was_robot_suite, sul-dlss/workflow-server-rails

------- COCINA REPORT -------
Found these versions of cocina in use:
    cocina-models (0.43.0)
    cocina-models (0.55.0)
    cocina-models (0.56.0)
    cocina-models (0.56.1)


found 0.43.0 in the following files:
was_robot_suite/Gemfile.lock


found 0.55.0 in the following files:
preservation_catalog/Gemfile.lock
hydra_etd/Gemfile.lock
was-registrar-app/Gemfile.lock
gis-robot-suite/Gemfile.lock


found 0.56.0 in the following files:
google-books/Gemfile.lock
pre-assembly/Gemfile.lock
happy-heron/Gemfile.lock
common-accessioning/Gemfile.lock
sdr-api/Gemfile.lock
dor-services-app/Gemfile.lock
dor_indexing_app/Gemfile.lock
hydrus/Gemfile.lock
```

## Why was this change made?



## How was this change tested?



## Which documentation and/or configurations were updated?



