### PR TITLE
touchups for slightly friendlier CLI operation

### DIFF
--- a/deploy.rb
+++ b/deploy.rb
@@ -89,12 +89,18 @@ unless %w[stage qa prod].include?(stage)
   exit
 end
 
-ssh_check = ARGV[1] == '--checkssh'
-check_cocina = ARGV[1] == '--check-cocina'
+mode = ARGV[1]
+ssh_check = mode == '--checkssh' || mode == '--ssh_check' || mode == '--sshcheck' # tolerance for those who forget the exact flag
+check_cocina = mode == '--check-cocina'
+unless (mode.nil? || ssh_check || check_cocina)
+  warn "Unrecognized mode of operation: #{mode}"
+  exit
+end
 
 auditor = Auditor.new
 
-puts "repos to #{ssh_check ? 'ssh_check' : 'deploy'}: #{repo_names.join(', ')}"
+mode_display = mode ? mode.gsub('--', '') : 'deploy'
+puts "repos to #{mode_display}: #{repo_names.join(', ')}"
 
 deploys = {}
 repo_infos.each do |repo_info|


### PR DESCRIPTION
## Why was this change made?

* more tolerant parsing of CLI args
* more accurate display of current mode in output
* guard against accidentally running in deploy mode when user provides arg for unrecognized mode

## How was this change tested?

locally:
```
sdr-deploy % ./deploy.rb stage --sshcheck # previously only 'checkssh' worked, and this would just launch deployment
repos to sshcheck: sul-dlss/argo, sul-dlss/common-accessioning, sul-dlss/dor-services-app, sul-dlss/dor_indexing_app, sul-dlss/gis-robot-suite, sul-dlss/google-books, sul-dlss/happy-heron, sul-dlss/hydra_etd, sul-dlss/hydrus, sul-dlss/modsulator-app-rails, sul-dlss/pre-assembly, sul-dlss/preservation_catalog, sul-dlss/preservation_robots, sul-dlss/robot-console, sul-dlss/sdr-api, sul-dlss/sul_pub, sul-dlss/suri-rails, sul-dlss/technical-metadata-service, sul-dlss/was-registrar-app, sul-dlss/was_robot_suite, sul-dlss/workflow-server-rails
Installing gems for tmp/repos/sul-dlss/argo
running 'cap stage ssh_check' for tmp/repos/sul-dlss/argo
Pseudo-terminal will not be allocated because stdin is not a terminal.
Pseudo-terminal will not be allocated because stdin is not a terminal.
Pseudo-terminal will not be allocated because stdin is not a terminal.
Pseudo-terminal will not be allocated because stdin is not a terminal.
```

```
sdr-deploy % ./deploy.rb stage --cocina-upgrade # not something this script does 
Unrecognized mode of operation: --cocina-upgrade
```

## Which documentation and/or configurations were updated?

n/a, just makes existing operation a little safer