### PR TITLE
update status url for h2 prod

### DIFF
--- a/repos.yml
+++ b/repos.yml
@@ -32,7 +32,7 @@ repo: sul-dlss/happy-heron
 status:
   qa: https://sul-h2-qa.stanford.edu/status/all/
   stage: https://sul-h2-stage.stanford.edu/status/all/
-  prod: https://sul-h2-prod.stanford.edu/status/all/
+  prod: https://new-sdr.stanford.edu/status/all/
 ---
 repo: sul-dlss/hydra_etd
 status:


### PR DESCRIPTION
## Why was this change made?

To get a successful status from the script instead of a failure due to 301

## How was this change tested?



## Which documentation and/or configurations were updated?



