### PR TITLE
check cocina-models version consistency after repos are updated

### DIFF
--- a/deploy.rb
+++ b/deploy.rb
@@ -122,9 +122,20 @@ mode_display = mode ? mode.gsub('--', '') : 'deploy'
 puts "repos to #{mode_display}: #{repo_names.join(', ')}"
 
 
+repo_infos.each do |repo_info|
+  repo = repo_info['repo']
+  repo_dir = File.join(WORK_DIR, repo)
+  puts "\n-------------------- updating #{repo}... --------------------\n"
+  update_or_create_repo(repo_dir, repo)
+  puts "\n-------------------- ...updated #{repo}  --------------------\n"
+end
+
 unless ssh_check || check_cocina
   # Runs cocina check before deployment
-  exit unless cocina_check
+  unless cocina_check
+    puts 'ABORTING: multiple versions of the cocina-models gem are in use'
+    exit
+  end
 end
 
 deploys = {}
@@ -132,7 +143,6 @@ repo_infos.each do |repo_info|
   repo = repo_info['repo']
   repo_dir = File.join(WORK_DIR, repo)
   puts "\n-------------------- BEGIN #{repo} --------------------\n" unless ssh_check || check_cocina
-  update_or_create_repo(repo_dir, repo)
   next if check_cocina
 
   auditor.audit(repo: repo, dir: repo_dir) unless ssh_check

--- a/deploy.rb
+++ b/deploy.rb
@@ -105,7 +105,7 @@ unless %w[stage qa prod].include?(stage)
   warn 'Usage:'
   warn "  #{$PROGRAM_NAME} <stage>"
   warn "\n  stage must be one of \"stage\",\"qa\",\"prod\"\n\n"
-  exit
+  exit(1)
 end
 
 mode = ARGV[1]
@@ -113,7 +113,7 @@ ssh_check = ['--checkssh', '--ssh_check', '--sshcheck'].include?(mode) # toleran
 check_cocina = mode == '--check-cocina'
 unless (mode.nil? || ssh_check || check_cocina)
   warn "Unrecognized mode of operation: #{mode}"
-  exit
+  exit(1)
 end
 
 auditor = Auditor.new
@@ -134,7 +134,7 @@ unless ssh_check || check_cocina
   # Runs cocina check before deployment
   unless cocina_check
     puts 'ABORTING: multiple versions of the cocina-models gem are in use'
-    exit
+    exit(1)
   end
 end
 


### PR DESCRIPTION
## Why was this change made?

implement suggestion on #53

bonus: use a consistent non-zero exit code when the script exits early

## How was this change tested?

running locally, i:
* edited the `deploy` function on line 64 so that it would `check_ssh` instead of `deploy`ing (so i could test without really deploying).  then i ran ` ./deploy.rb qa`.
* kept the above `check_ssh` edit, then edited the new `cocina_check` method to always return `false` so that i could test the abort behavior.  then i ran ` ./deploy.rb qa`.

## Which documentation and/or configurations were updated?

n/a