### PR TITLE
sdr-api status urls: use status/all

### DIFF
--- a/repos.yml
+++ b/repos.yml
@@ -72,9 +72,9 @@ repo: sul-dlss/robot-console
 ---
 repo: sul-dlss/sdr-api
 status:
-  qa: https://sdr-api-qa.stanford.edu/status
-  stage: https://sdr-api-stage.stanford.edu/status
-  prod: https://sdr-api-prod.stanford.edu/status
+  qa: https://sdr-api-qa.stanford.edu/status/all
+  stage: https://sdr-api-stage.stanford.edu/status/all
+  prod: https://sdr-api-prod.stanford.edu/status/all
 ---
 repo: sul-dlss/sul_pub
 status:


### PR DESCRIPTION
## Why was this change made?

to get more checks used for sdr-api (and make it like all the other repos)

## How was this change tested?



## Which documentation and/or configurations were updated?



