### PR TITLE
README:  include information about contribsys gem credentials for google-books

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,6 +82,7 @@ GEM
     unicode_utils (1.4.0)
 
 PLATFORMS
+  x86_64-darwin-19
   x86_64-linux
 
 DEPENDENCIES

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Make sure that:
 * You have added the public SSH key, often `~/.ssh/id_rsa.pub`, from your machine to [GitHub](https://github.com/settings/keys)
 * You have previously `ssh`-ed into all servers.
   * NOTE: If you are unsure about this, run `bin/check_ssh -e [qa|stage|prod]` and watch the output for any errors!
+* NOTE: if you run `check_cocina`, you may need to ensure that you have the contribsys gem credentials available for google-books to install the sidekiq-pro gem locally (the credential is already on our deploy target VMs).
+  * You can get the env variable name and value from shared_configs for google-books-prod -- it's in the shared_configs README. (And it's not in google-books -stage or -qa branches of shared_configs)
 * NOTE: You *may* invoke the `bin/` scripts via `bundle exec`.
 
 ### Check your SSH connection to all servers


### PR DESCRIPTION
## Why was this change made?

To help the next person who hits the problem I hit.  :-P

## How was this change tested?



## Which documentation and/or configurations were updated?



