### PR TITLE
Add ability to operate on a subset of repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,16 @@ Make sure that:
 ### Check your SSH connection to all servers
 
 ```
-# Add -s flag to skip the local repo update
 bin/check_ssh -e qa # or stage or prod
+
+# Add -s flag to skip the local repo update
+bin/check_ssh -s -e qa
+
+# Add --only flag to only check one or more named repos
+bin/check_ssh -e qa --only sul-dlss/technical-metadata-service sul-dlss/argo
+
+# Add --except flag to check all but one or more named repos
+bin/check_ssh -e qa --except sul-dlss/technical-metadata-service sul-dlss/argo
 ```
 
 NOTE: Watch the output for any errors
@@ -38,6 +46,15 @@ This will let you know which versions of cocina-models each project is locked to
 
 ```
 bin/deploy -e qa # or stage or prod
+
+# Add -s flag to skip the local repo update
+bin/deploy -s -e qa
+
+# Add --only flag to only deploy one or more named repos
+bin/deploy -e qa --only sul-dlss/technical-metadata-service sul-dlss/argo
+
+# Add --except flag to deploy all but one or more named repos
+bin/deploy -e qa --except sul-dlss/technical-metadata-service sul-dlss/argo
 ```
 
 Note:

--- a/bin/check_cocina
+++ b/bin/check_cocina
@@ -11,7 +11,7 @@ class CheckCocina < Thor
 
   desc 'check_cocina', 'check cocina versions'
   def check_cocina
-    RepoUpdater.update_all
+    RepoUpdater.update(repos: Settings.repositories)
     CocinaChecker.check
   end
 

--- a/bin/check_ssh
+++ b/bin/check_ssh
@@ -9,6 +9,16 @@ require 'sdr_deploy'
 class CheckSsh < Thor
   default_task :check_ssh
 
+  option :only,
+         type: :array,
+         default: [],
+         desc: 'Update only these repos'
+
+  option :except,
+         type: :array,
+         default: [],
+         desc: 'Update all except these repos'
+
   option :skip_update,
          type: :boolean,
          default: false,
@@ -24,12 +34,26 @@ class CheckSsh < Thor
 
   desc 'check_ssh', 'check SSH connections'
   def check_ssh
-    RepoUpdater.update_all unless options[:skip_update]
-    SshChecker.check(environment: options[:environment])
+    raise Thor::Error, 'Use only one of --only or --except' if options[:only].any? && options[:except].any?
+
+    RepoUpdater.update(repos: repositories) unless options[:skip_update]
+    SshChecker.check(environment: options[:environment], repos: repositories)
   end
 
   def self.exit_on_failure?
     true
+  end
+
+  private
+
+  def repositories
+    if options[:only].any?
+      Settings.repositories.select { |repo| options[:only].include?(repo.name) }
+    elsif options[:except].any?
+      Settings.repositories.reject { |repo| options[:except].include?(repo.name) }
+    else
+      Setting.repositories
+    end
   end
 end
 

--- a/bin/deploy
+++ b/bin/deploy
@@ -9,6 +9,22 @@ require 'sdr_deploy'
 class Deploy < Thor
   default_task :deploy
 
+  option :only,
+         type: :array,
+         default: [],
+         desc: 'Update only these repos'
+
+  option :except,
+         type: :array,
+         default: [],
+         desc: 'Update all except these repos'
+
+  option :skip_update,
+         type: :boolean,
+         default: false,
+         desc: 'Skip update repos',
+         aliases: '-s'
+
   option :environment,
          required: true,
          enum: Settings.supported_envs,
@@ -18,14 +34,28 @@ class Deploy < Thor
 
   desc 'deploy', 'deploy all the services in an environment'
   def deploy
-    RepoUpdater.update_all
+    raise Thor::Error, 'Use only one of --only or --except' if options[:only].any? && options[:except].any?
+
+    RepoUpdater.update(repos: repositories) unless options[:skip_update]
     abort 'ABORTING: multiple versions of the cocina-models gem are in use' unless CocinaChecker.check
 
-    Deployer.deploy(environment: options[:environment])
+    Deployer.deploy(environment: options[:environment], repos: repositories)
   end
 
   def self.exit_on_failure?
     true
+  end
+
+  private
+
+  def repositories
+    if options[:only].any?
+      Settings.repositories.select { |repo| options[:only].include?(repo.name) }
+    elsif options[:except].any?
+      Settings.repositories.reject { |repo| options[:except].include?(repo.name) }
+    else
+      Setting.repositories
+    end
   end
 end
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -81,7 +81,7 @@ repositories:
   - name: sul-dlss/technical-metadata-service
     status:
       qa: https://dor-techmd-qa.stanford.edu/status/all/
-      stage: https://dor-techmd-stage.stanford.edu/status/all/
+      stage: https://dor-techmd-stage-a.stanford.edu/status/all/
       prod: https://dor-techmd-prod.stanford.edu/status/all/
   - name: sul-dlss/was-registrar-app
     status:

--- a/lib/deployer.rb
+++ b/lib/deployer.rb
@@ -5,14 +5,15 @@ require 'net/http'
 
 # Service class for deploying
 class Deployer
-  def self.deploy(environment:)
-    new(environment: environment).deploy_all
+  def self.deploy(environment:, repos:)
+    new(environment: environment, repos: repos).deploy_all
   end
 
-  attr_reader :environment
+  attr_reader :environment, :repos
 
-  def initialize(environment:)
+  def initialize(environment:, repos:)
     @environment = environment
+    @repos = repos
   end
 
   def deploy_all
@@ -47,10 +48,6 @@ class Deployer
   end
 
   private
-
-  def repos
-    @repos ||= Settings.repositories
-  end
 
   def auditor
     @auditor ||= Auditor.new

--- a/lib/repo_updater.rb
+++ b/lib/repo_updater.rb
@@ -4,21 +4,22 @@ require 'fileutils'
 
 # Update locally cached git repositories
 class RepoUpdater
-  def self.update_all
-    progress_bar.start
-    Settings.repositories.each do |repo|
+  def self.update(repos:)
+    @progress_bar = progress_bar(repos)
+    @progress_bar.start
+    repos.each do |repo|
       new(repo: repo.name).tap do |updater|
-        progress_bar.advance(repo: repo.name, operation: updater.operation_label)
+        @progress_bar.advance(repo: repo.name, operation: updater.operation_label)
         updater.update_or_create_repo
       end
     end
   end
 
-  def self.progress_bar
-    @progress_bar ||= TTY::ProgressBar.new(
+  def self.progress_bar(repos)
+    TTY::ProgressBar.new(
       ':operation cached git repository [:bar] (:current/:total, ETA: :eta) :repo',
       bar_format: :crate,
-      total: Settings.repositories.count
+      total: repos.count
     )
   end
   private_class_method :progress_bar

--- a/lib/ssh_checker.rb
+++ b/lib/ssh_checker.rb
@@ -2,14 +2,15 @@
 
 # Service class for checking SSH connections
 class SshChecker
-  def self.check(environment:)
-    new(environment: environment).check_ssh
+  def self.check(environment:, repos:)
+    new(environment: environment, repos: repos).check_ssh
   end
 
-  attr_reader :environment
+  attr_reader :environment, :repos
 
-  def initialize(environment:)
+  def initialize(environment:, repos:)
     @environment = environment
+    @repos = repos
   end
 
   def check_ssh
@@ -20,11 +21,5 @@ class SshChecker
         ErrorEmittingExecutor.execute("bundle exec cap #{environment} ssh_check")
       end
     end
-  end
-
-  private
-
-  def repos
-    @repos ||= Settings.repositories
   end
 end


### PR DESCRIPTION

## Why was this change made?

To make it easier to operate on a subset of repositories. Now requires no temporary config hacks.

Includes:
* Add new, mutually exclusive `--only` and `--except` options to `bin/deploy` and `bin/check_ssh`
* Add support for `-s` flag to `bin/deploy` (previously only available to `bin/check_ssh`)
* Fix outdated staging URL for technical metadata service causing status report to fail
* Update README to document new options

## How was this change tested?

Ran all commands against all envs with different options. 🤷🏻 

## Which documentation and/or configurations were updated?

README

