### PR TITLE
Fix typo Setting -> Settings

### DIFF
--- a/bin/check_ssh
+++ b/bin/check_ssh
@@ -52,7 +52,7 @@ class CheckSsh < Thor
     elsif options[:except].any?
       Settings.repositories.reject { |repo| options[:except].include?(repo.name) }
     else
-      Setting.repositories
+      Settings.repositories
     end
   end
 end


### PR DESCRIPTION
## Why was this change made?

This fixes an error message I'm getting:

```
Traceback (most recent call last):
	6: from bin/check_ssh:60:in `<main>'
	5: from /Users/amcollie/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/thor-1.1.0/lib/thor/base.rb:485:in `start'
	4: from /Users/amcollie/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/thor-1.1.0/lib/thor.rb:392:in `dispatch'
	3: from /Users/amcollie/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/thor-1.1.0/lib/thor/invocation.rb:127:in `invoke_command'
	2: from /Users/amcollie/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/thor-1.1.0/lib/thor/command.rb:27:in `run'
	1: from bin/check_ssh:40:in `check_ssh'
bin/check_ssh:55:in `repositories': uninitialized constant CheckSsh::Setting (NameError)
Did you mean?  Settings
               String
```


## How was this change tested?



## Which documentation and/or configurations were updated?



