### PR TITLE
Permit deploying when there are no cocina versions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,6 +83,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-19
+  x86_64-darwin-21
   x86_64-linux
 
 DEPENDENCIES
@@ -95,4 +96,4 @@ DEPENDENCIES
   tty-table (~> 0.12)
 
 BUNDLED WITH
-   2.2.30
+   2.3.4

--- a/lib/cocina_checker.rb
+++ b/lib/cocina_checker.rb
@@ -27,7 +27,7 @@ class CocinaChecker
     end
 
     # `true` is the happy path; `false` means dragons
-    unique_values.size == 1
+    unique_values.size <= 1
   end
 
   private


### PR DESCRIPTION
This can happen if you use: --only sul-dlss/suri-rails

## Why was this change made?



## How was this change tested?



## Which documentation and/or configurations were updated?



