### PR TITLE
README: prescat is now ruby 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,12 +64,12 @@ As of Jan 2022, some projects have not yet been updated to be Ruby 3.0 compatibl
 In Ruby 3.0
 
 ```
-bin/deploy -e stage --except sul-dlss/dor-services-app sul-dlss/ksr-app sul-dlss/preservation_catalog
+bin/deploy -e stage --except sul-dlss/dor-services-app sul-dlss/ksr-app
 ```
 
 Then in Ruby 2.7
 ```
-bin/deploy -e stage --only sul-dlss/dor-services-app sul-dlss/ksr-app sul-dlss/preservation_catalog
+bin/deploy -e stage --only sul-dlss/dor-services-app sul-dlss/ksr-app
 ```
 
 The 4 projects that still use ruby 2.7 should eventually be converted to Ruby 3.0


### PR DESCRIPTION
## Why was this change made?

prescat VMs are now ruby 3

## How was this change tested?



## Which documentation and/or configurations were updated?



