### PR TITLE
do not deploy argo automatically during workcycle

### DIFF
--- a/bin/deploy
+++ b/bin/deploy
@@ -59,4 +59,15 @@ class Deploy < Thor
   end
 end
 
+def warning
+  puts '*************************'
+  puts 'WARNING! (added jan 2022)'
+  puts "Argo is commented out in config/settings.yml since we don't want to"
+  puts 'automatically deploy Argo to production during the Fedora removal workcycle!'
+  puts 'Add back in when workcycle is complete.  You should still deploy Argo to qa/stage manually.'
+  puts '*************************'
+end
+
+warning
 Deploy.start(ARGV)
+warning

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -4,11 +4,13 @@ supported_envs:
   - prod
   - stage
 repositories:
-  - name: sul-dlss/argo
-    status:
-      qa: https://argo-qa.stanford.edu/status/all/
-      stage: https://argo-stage.stanford.edu/status/all/
-      prod: https://argo.stanford.edu/status/all/
+  # JAN 13 2022 Do not automatically deploy Argo to production during the Fedora removal workcycle!
+  #  uncomment out when workcycle is complete and remove warning message in bin/deploy
+  # - name: sul-dlss/argo
+  #   status:
+  #     qa: https://argo-qa.stanford.edu/status/all/
+  #     stage: https://argo-stage.stanford.edu/status/all/
+  #     prod: https://argo.stanford.edu/status/all/
   - name: sul-dlss/common-accessioning
   - name: sul-dlss/dor-services-app
     status:


### PR DESCRIPTION
## Why was this change made?

Do not automatically deploy Argo during the Fedora 3 workcycle, and show warning when deploying.

## How was this change tested?



## Which documentation and/or configurations were updated?



