### PR TITLE
when checking cocina version, skip any repos not in settings.yml

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,4 +1,5 @@
 work_dir: tmp/repos
+gem_filename: Gemfile.lock
 supported_envs:
   - qa
   - prod

--- a/lib/cocina_checker.rb
+++ b/lib/cocina_checker.rb
@@ -7,9 +7,13 @@ class CocinaChecker
   end
 
   def check_cocina
-    puts "repos to Cocina check: #{repos.map(&:name).join(', ')}"
+    gem_filename = 'Gemfile.lock'
+    repo_names = repos.map(&:name)
+    puts "repos to Cocina check: #{repo_names.join(', ')}"
+    version_map = Dir["#{base_directory}**/#{gem_filename}"].filter_map do |lockfile_path|
+      cached_repo_name = lockfile_path.gsub(base_directory, '').gsub(gem_filename, '').chomp('/')
+      next unless repo_names.include? cached_repo_name # skip any cached repo not found in the settings.yml file
 
-    version_map = Dir["#{base_directory}**/Gemfile.lock"].filter_map do |lockfile_path|
       cocina_models_version = cocina_version_from(lockfile_path)
       next if cocina_models_version.empty?
 

--- a/lib/cocina_checker.rb
+++ b/lib/cocina_checker.rb
@@ -7,12 +7,11 @@ class CocinaChecker
   end
 
   def check_cocina
-    gem_filename = 'Gemfile.lock'
     repo_names = repos.map(&:name)
     puts "repos to Cocina check: #{repo_names.join(', ')}"
-    version_map = Dir["#{base_directory}**/#{gem_filename}"].filter_map do |lockfile_path|
-      cached_repo_name = lockfile_path.gsub(base_directory, '').gsub(gem_filename, '').chomp('/')
-      next unless repo_names.include? cached_repo_name # skip any cached repo not found in the settings.yml file
+    version_map = Dir["#{base_directory}**/#{Settings.gem_filename}"].filter_map do |lockfile_path|
+      # skip any cached repo not found in the settings.yml file
+      next unless repo_names.include? project_name_for(lockfile_path).chomp('/')
 
       cocina_models_version = cocina_version_from(lockfile_path)
       next if cocina_models_version.empty?


### PR DESCRIPTION
## Why was this change made?

Previously configured but no longer in use repos (e.g. hydrus) will still have entries in the `tmp/repos` folder, and our current code will continue to check the cocina version of these repos even though they aren't being updated anymore.  This change will skip any repos in that local folder that are not configured in the `settings.yml` file

## How was this change tested?

Localhost


## Which documentation and/or configurations were updated?



