### PR TITLE
remove unused local repos when updating

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,10 +95,7 @@ bin/deploy -e stage -c --only sul-dlss/dor-services-app
 
 ### Notes and tips:
 * All repos will be cloned to `tmp/repos`.
-* Any repos cloned to `tmp/repos` that are no longer configured in the `settings.yml` file will
-be automatically removed when you deploy or check cocina versions to prevent outdated code from
-being checked.  If you add the repo back to the `settings.yml` file again later, it will be re-cloned
-automatically.
+* Any repos cloned to `tmp/repos` that are removed from `config/settings.yml`, *e.g.* projects that have been decommissioned, will be automatically removed from `tmp/repos` the next time any of the sdr-depoy commands are run (unless the repo update is explicitly skipped via user-provided flag).
 * If you prefer your output in color, this will work:
 ```
 export SSHKIT_COLOR='TRUE'

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ The 4 projects that still use ruby 2.7 should eventually be converted to Ruby 3.
 
 Note: this includes dor-services-app and sdr-api in addition to cocina level2 updates.
 
-Use the `--cocina` or `-c` flag.  
+Use the `--cocina` or `-c` flag.
 
 In Ruby 3.0
 
@@ -95,6 +95,10 @@ bin/deploy -e stage -c --only sul-dlss/dor-services-app
 
 ### Notes and tips:
 * All repos will be cloned to `tmp/repos`.
+* Any repos cloned to `tmp/repos` that are no longer configured in the `settings.yml` file will
+be automatically removed when you deploy or check cocina versions to prevent outdated code from
+being checked.  If you add the repo back to the `settings.yml` file again later, it will be re-cloned
+automatically.
 * If you prefer your output in color, this will work:
 ```
 export SSHKIT_COLOR='TRUE'

--- a/lib/repo_updater.rb
+++ b/lib/repo_updater.rb
@@ -2,9 +2,20 @@
 
 require 'fileutils'
 
-# Update locally cached git repositories
+# Update locally cached git repositories, remove extraneous ones
 class RepoUpdater
   def self.update(repos:)
+    tmp_repos = Dir["#{Settings.work_dir}/*/*"].filter_map do |entry|
+      entry.gsub("#{Settings.work_dir}/", '') if File.directory? entry
+    end
+    repo_names = repos.map(&:name)
+    tmp_repos.each do |tmp_repo|
+      unless repo_names.include? tmp_repo
+        puts "Removing locally cached repo #{tmp_repo}"
+        new(repo: tmp_repo).delete_repo
+      end
+    end
+
     @progress_bar = progress_bar(repos)
     @progress_bar.start
     repos.each do |repo|
@@ -47,6 +58,10 @@ class RepoUpdater
     else
       create_repo
     end
+  end
+
+  def delete_repo
+    FileUtils.rm_rf(repo_dir)
   end
 
   def update_repo

--- a/lib/repo_updater.rb
+++ b/lib/repo_updater.rb
@@ -5,6 +5,8 @@ require 'fileutils'
 # Update locally cached git repositories, remove extraneous ones
 class RepoUpdater
   def self.update(repos:)
+    # first look through all of the locally cached repos in the working directory,
+    #  and then remove any that are not configured in the settings.yml file (they are likely deprecated)
     tmp_repos = Dir["#{Settings.work_dir}/*/*"].filter_map do |entry|
       entry.gsub("#{Settings.work_dir}/", '') if File.directory? entry
     end


### PR DESCRIPTION
## Why was this change made?

Alternative to #96, just remove local repos that are not configured when updating, to prevent confusion when checking cocina versions.

## How was this change tested?

Localhost


## Which documentation and/or configurations were updated?



