### PR TITLE
Fix rubocop config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,8 @@ AllCops:
   TargetRubyVersion: 3.0
   DisplayCopNames: true
   Exclude:
-    - Gemfile
+    - tmp/repos/**/*
+
 
 # The behavior of RuboCop can be controlled via the .rubocop.yml
 # configuration file. It makes it possible to enable/disable


### PR DESCRIPTION
Prior to this commit, Rubocop was scanning all the files in tmp/repos/ and also picking up configuration from these projects, preventing it from running
