### PR TITLE
add new ksr status check endpoints to deployment script

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -47,6 +47,10 @@ repositories:
       stage: https://etd-stage.stanford.edu/status/all/
       prod:  https://etd.stanford.edu/status/all/
   - name: sul-dlss/ksr-app
+    status:
+      qa: https://ksr-search-dev.stanford.edu/status/all/
+      stage: https://ksr-search-stage.stanford.edu/status/all/
+      prod: https://ksr-search-prod.stanford.edu/status/all/
   - name: sul-dlss/modsulator-app-rails
   - name: sul-dlss/pre-assembly
     cocina_models_update: true


### PR DESCRIPTION
## Why was this change made?

ksr status checks are being added in https://github.com/sul-dlss/ksr-app/pull/12 .... we can then check them after that is merged


## How was this change tested?



## Which documentation and/or configurations were updated?



