### PR TITLE
update url for techmd-prod status check

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -92,7 +92,7 @@ repositories:
     status:
       qa: https://dor-techmd-qa.stanford.edu/status/all/
       stage: https://dor-techmd-stage-a.stanford.edu/status/all/
-      prod: https://dor-techmd-prod.stanford.edu/status/all/
+      prod: https://dor-techmd-prod-a.stanford.edu/status/all/
   - name: sul-dlss/was-registrar-app
     status:
       qa: https://was-registrar-app-qa.stanford.edu/status/all/


### PR DESCRIPTION
## Why was this change made?

Status check for techmd-prod is going to a non-responding URL.  i updated to the current deploy target, which works... see https://github.com/sul-dlss/technical-metadata-service/blob/main/config/deploy/prod.rb

## How was this change tested?



## Which documentation and/or configurations were updated?



