### PR TITLE
Prefer prescat 02 VMs for status checks

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -60,13 +60,13 @@ repositories:
       prod: https://sul-preassembly-prod.stanford.edu/status/all/
   - name: sul-dlss/preservation_catalog
     status:
-      qa: https://preservation-catalog-qa-01.stanford.edu/status/all/
-      stage: https://preservation-catalog-stage-01.stanford.edu/status/all/
+      qa: https://preservation-catalog-qa-02.stanford.edu/status/all/
+      stage: https://preservation-catalog-stage-02.stanford.edu/status/all/
       prod: https://preservation-catalog-prod-02.stanford.edu/status/all/
-      # NOTE: the /status/all check fails on https://preservation-catalog-prod-01.stanford.edu, because the
+      # NOTE: the /status/all check fails on https://preservation-catalog-*-01.stanford.edu, because the
       # `feature-zip_storage_dir` check (confirm that `/sdr-transfers` is writable) fails on that box.
-      # That is expected, and preservation-catalog-prod-02 should pass. This is because only the resque worker
-      # boxes (-02 through -04) mount that directory. (this is actually true of pres cat -01 VMs in all envs)
+      # That is expected, and preservation-catalog-*-02 should pass. This is because only the resque worker
+      # boxes (-02 through -04) mount that directory.
   - name: sul-dlss/preservation_robots
   - name: sul-dlss/robot-console
   - name: sul-dlss/sdr-api


### PR DESCRIPTION
Because this is the box that mounts the zip transfers dir and it avoids a failing status check. @jmartin-sul said so.
