### PR TITLE
pres cat: hit a VM that mounts the zip temp space

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -60,8 +60,8 @@ repositories:
       prod: https://sul-preassembly-prod.stanford.edu/status/all/
   - name: sul-dlss/preservation_catalog
     status:
-      qa: https://preservation-catalog-qa-01.stanford.edu/status/all/
-      stage: https://preservation-catalog-stage-01.stanford.edu/status/all/
+      qa: https://preservation-catalog-qa-02.stanford.edu/status/all/
+      stage: https://preservation-catalog-stage-02.stanford.edu/status/all/
       prod: https://preservation-catalog-prod-02.stanford.edu/status/all/
       # NOTE: the /status/all check fails on https://preservation-catalog-prod-01.stanford.edu, because the
       # `feature-zip_storage_dir` check (confirm that `/sdr-transfers` is writable) fails on that box.


### PR DESCRIPTION
## Why was this change made?

otherwise, the check for whether it's available will fail (expected since the -01 VMs don't mount it)

## How was this change tested?

manually went to the updated URLs to confirm they work

## Which documentation and/or configurations were updated?



