### PR TITLE
Add ability to deploy a given tag for every repository

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -119,3 +119,5 @@ Style/FileWrite: # new in 1.24
   Enabled: true
 Style/MapToHash: # new in 1.24
   Enabled: true
+Style/NestedFileDirname: # new in 1.26
+  Enabled: true

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Options:
       [--only=one two three]               # Update only these repos
       [--except=one two three]             # Update all except these repos
   -c, [--cocina], [--no-cocina]            # Only update repos affected by new cocina-models gem release
+  -t, [--tag=TAG]                          # Deploy the given tag instead of the main branch
   -s, [--skip-update], [--no-skip-update]  # Skip update repos
   -e, --environment=ENVIRONMENT            # Environment (["qa", "prod", "stage"])
                                            # Possible values: qa, prod, stage

--- a/bin/deploy
+++ b/bin/deploy
@@ -25,6 +25,11 @@ class Deploy < Thor
          desc: 'Only update repos affected by new cocina-models gem release',
          aliases: '-c'
 
+  option :tag,
+         type: :string,
+         desc: 'Deploy the given tag instead of the main branch',
+         aliases: '-t'
+
   option :skip_update,
          type: :boolean,
          default: false,
@@ -45,7 +50,7 @@ class Deploy < Thor
     RepoUpdater.update(repos: repositories, prune: prune?) unless options[:skip_update]
     abort 'ABORTING: multiple versions of the cocina-models gem are in use' unless CocinaChecker.check
 
-    Deployer.deploy(environment: options[:environment], repos: repositories)
+    Deployer.deploy(environment: options[:environment], repos: repositories, tag: options[:tag])
   end
 
   def self.exit_on_failure?


### PR DESCRIPTION
Fixes #77

## Why was this change made?

This is a logical follow-up to the earlier commit that added the ability to tag a bunch of repos. It lets us deploy a specified tag instead of always deploying the latest in `main`. See #77 for more.

As part of this work, add a new check to the deployer that prevents a tag-based deploy if not all implicated repos have the tag already created.

## How was this change tested?

Ran a bunch of tests in QA.

## Which documentation and/or configurations were updated?

README
