### PR TITLE
deployer.rb repos_missing_tag: RepoUpdater wants a repo object (not just the string with its name)

### DIFF
--- a/lib/deployer.rb
+++ b/lib/deployer.rb
@@ -63,7 +63,7 @@ class Deployer
 
   def repos_missing_tag
     @repos_missing_tag ||= repos.reject do |repo|
-      Dir.chdir(RepoUpdater.new(repo: repo.name).repo_dir) { `git tag`.split.include?(tag) }
+      Dir.chdir(RepoUpdater.new(repo: repo).repo_dir) { `git tag`.split.include?(tag) }
     end.map(&:name)
   end
 


### PR DESCRIPTION
## Why was this change made?

previously, if i tried to deploy with a tag, i'd get an error like:

```
% bin/sdr deploy -t rel-2022-04-04 -e stage --except sul-dlss/dor-services-app        main
updating cached git repository [▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣] (19/19, ETA:  0s) sul-dlss/workflow-server-rails     
repos to Cocina check: sul-dlss/common-accessioning, sul-dlss/dor_indexing_app, sul-dlss/gis-robot-suite, sul-dlss/google-books, sul-dlss/happy-heron, sul-dlss/hydra_etd, sul-dlss/ksr-app, sul-dlss/modsulator-app-rails, sul-dlss/pre-assembly, sul-dlss/preservation_catalog, sul-dlss/preservation_robots, sul-dlss/robot-console, sul-dlss/sdr-api, sul-dlss/sul_pub, sul-dlss/suri-rails, sul-dlss/technical-metadata-service, sul-dlss/was-registrar-app, sul-dlss/was_robot_suite, sul-dlss/workflow-server-rails
------- COCINA REPORT -------
Found these versions of cocina in use:
  0.71.0
    sul-dlss/common-accessioning
    sul-dlss/dor_indexing_app
    sul-dlss/gis-robot-suite
    sul-dlss/google-books
    sul-dlss/happy-heron
    sul-dlss/hydra_etd
    sul-dlss/pre-assembly
    sul-dlss/preservation_catalog
    sul-dlss/sdr-api
    sul-dlss/was-registrar-app
    sul-dlss/was_robot_suite
/Users/jmartin-sul/software_dev_projects/sdr-deploy/lib/repo_updater.rb:41:in `initialize': undefined method `name' for "sul-dlss/common-accessioning":String (NoMethodError)
  from /Users/jmartin-sul/software_dev_projects/sdr-deploy/lib/deployer.rb:66:in `new'
  from /Users/jmartin-sul/software_dev_projects/sdr-deploy/lib/deployer.rb:66:in `block in repos_missing_tag'
  from /Users/jmartin-sul/software_dev_projects/sdr-deploy/lib/deployer.rb:65:in `reject'
  from /Users/jmartin-sul/software_dev_projects/sdr-deploy/lib/deployer.rb:65:in `repos_missing_tag'
  from /Users/jmartin-sul/software_dev_projects/sdr-deploy/lib/deployer.rb:59:in `ensure_tag_present_in_all_repos!'
  from /Users/jmartin-sul/software_dev_projects/sdr-deploy/lib/deployer.rb:18:in `initialize'
  from /Users/jmartin-sul/software_dev_projects/sdr-deploy/lib/deployer.rb:9:in `new'
  from /Users/jmartin-sul/software_dev_projects/sdr-deploy/lib/deployer.rb:9:in `deploy'
  from bin/sdr:126:in `deploy'
  from /Users/jmartin-sul/.rbenv/versions/3.0.3/lib/ruby/gems/3.0.0/gems/thor-1.2.1/lib/thor/command.rb:27:in `run'
  from /Users/jmartin-sul/.rbenv/versions/3.0.3/lib/ruby/gems/3.0.0/gems/thor-1.2.1/lib/thor/invocation.rb:127:in `invoke_command'
  from /Users/jmartin-sul/.rbenv/versions/3.0.3/lib/ruby/gems/3.0.0/gems/thor-1.2.1/lib/thor.rb:392:in `dispatch'
  from /Users/jmartin-sul/.rbenv/versions/3.0.3/lib/ruby/gems/3.0.0/gems/thor-1.2.1/lib/thor/base.rb:485:in `start'
  from bin/sdr:130:in `<main>'
```

this change seemed to fix it, and allowed deployments to proceed (about halfway through stage deployment right now, will take out of draft if fully successful).

## How was this change tested?



## Which documentation and/or configurations were updated?



