### PR TITLE
Add cocina flag to WAS repos

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -103,6 +103,7 @@ repositories:
       stage: https://dor-techmd-stage-a.stanford.edu/status/all/
       prod: https://dor-techmd-prod-a.stanford.edu/status/all/
   - name: sul-dlss/was-registrar-app
+    cocina_models_update: true
     status:
       qa: https://was-registrar-app-qa.stanford.edu/status/all/
       stage: https://was-registrar-app-stage.stanford.edu/status/all/
@@ -110,7 +111,6 @@ repositories:
   - name: sul-dlss/was_robot_suite
     cocina_models_update: true
   - name: sul-dlss/workflow-server-rails
-    cocina_models_update: true
     # workflow-server-rails is locked down on all environments and status cannot be checked remotely
     # you can check manually using curl from the corresponding argo vms
     # status:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -108,7 +108,9 @@ repositories:
       stage: https://was-registrar-app-stage.stanford.edu/status/all/
       prod: https://was-registrar-app.stanford.edu/status/all/
   - name: sul-dlss/was_robot_suite
+    cocina_models_update: true
   - name: sul-dlss/workflow-server-rails
+    cocina_models_update: true
     # workflow-server-rails is locked down on all environments and status cannot be checked remotely
     # you can check manually using curl from the corresponding argo vms
     # status:


### PR DESCRIPTION
## Why was this change made?

Because WAS repos are cocina-aware and should be deployed among the cocina repos.
