### PR TITLE
require a tag to deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Options:
       [--only=one two three]               # Update only these repos
       [--except=one two three]             # Update all except these repos
   -c, [--cocina], [--no-cocina]            # Only update repos affected by new cocina-models gem release
-  -t, [--tag=TAG]                          # Deploy the given tag instead of the main branch
+  -t, [--tag=TAG]                          # Deploy the given tag (required) ... set to "main" to deploy the main branch (and confirm)
   -s, [--skip-update], [--no-skip-update]  # Skip update repos
   -e, --environment=ENVIRONMENT            # Environment (["qa", "prod", "stage"])
                                            # Possible values: qa, prod, stage

--- a/lib/deployer.rb
+++ b/lib/deployer.rb
@@ -16,7 +16,9 @@ class Deployer
     @environment = environment
     @repos = repos
     @tag = tag
-    ensure_tag_present_in_all_repos! if tag
+    raise '*** ERROR: You must supply a tag to deploy (can set to main and confirm) ***' unless @tag
+
+    ensure_tag_present_in_all_repos!
     prompt_user_for_main_confirmation!
     prompt_user_for_approval_confirmation!
   end


### PR DESCRIPTION
## Why was this change made?

For discussion in upcoming dev planning - this would require supplying a tag in order to deploy.  You can still deploy main by supplying the tag as "main", though this also requires confirmation (a previous change).

## How was this change tested?



## Which documentation and/or configurations were updated?



