### PR TITLE
Optionally run a user-provided command before deploying

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,10 @@ Options:
       [--only=one two three]               # Update only these repos
       [--except=one two three]             # Update all except these repos
   -c, [--cocina], [--no-cocina]            # Only update repos affected by new cocina-models gem release
+  -b, [--before-command=BEFORE_COMMAND]    # Run this command on each host before deploying
   -t, [--tag=TAG]                          # Deploy the given tag instead of the main branch
   -s, [--skip-update], [--no-skip-update]  # Skip update repos
-  -e, --environment=ENVIRONMENT            # Environment (["qa", "prod", "stage"])
+  -e, --environment=ENVIRONMENT            # Deployment environment
                                            # Possible values: qa, prod, stage
 
 deploy all the services in an environment
@@ -68,7 +69,13 @@ Example:
   bin/sdr deploy -s -e qa --only sul-dlss/technical-metadata-service sul-dlss/argo
 ```
 
-**NOTE 1**: We have a couple applications that use environments outside of our standard ones (qa, prod, and stage), and sdr-deploy deploys to these oddball environments when deploying to QA. These are configured on a per-application basis in `config/settings.yml` via, .e.g.:
+**NOTE 1**: If you are deploying dependency changes and one of the default gems (e.g., `strscan`, `io-wait`) has been bumped, you may find it useful to use the `-b`/`--before-command` option as follows:
+
+```shell
+$ bin/sdr deploy -e stage -b 'bash -lc "gem install strscan"'
+```
+
+**NOTE 2**: We have a couple applications that use environments outside of our standard ones (qa, prod, and stage), and sdr-deploy deploys to these oddball environments when deploying to QA. These are configured on a per-application basis in `config/settings.yml` via, e.g.:
 
 ```yaml
   - name: sul-dlss/sul_pub
@@ -76,7 +83,7 @@ Example:
       - cap-dev
 ```
 
-**NOTE 2**: Sometimes we want to be extra careful when deploying certain apps to certain environments. These are configured on a per-application basis in `config/settings.yml` via, .e.g.:
+**NOTE 3**: Sometimes we want to be extra careful when deploying certain apps to certain environments. These are configured on a per-application basis in `config/settings.yml` via, e.g.:
 
 ```yaml
   - name: sul-dlss/argo

--- a/bin/sdr
+++ b/bin/sdr
@@ -100,6 +100,10 @@ class CLI < Thor
          default: false,
          desc: 'Only update repos affected by new cocina-models gem release',
          aliases: '-c'
+  option :before_command,
+         type: :string,
+         desc: 'Run this command on each host before deploying',
+         aliases: '-b'
   option :tag,
          type: :string,
          desc: 'Deploy the given tag instead of the main branch',
@@ -113,7 +117,7 @@ class CLI < Thor
          required: true,
          enum: Settings.supported_envs.keys.map(&:to_s),
          banner: 'ENVIRONMENT',
-         desc: "Environment (#{Settings.supported_envs.keys.map(&:to_s)})",
+         desc: 'Deployment environment',
          aliases: '-e'
   desc 'deploy', 'deploy all the services in an environment'
   def deploy
@@ -135,7 +139,12 @@ class CLI < Thor
     RepoUpdater.update(repos: repositories, prune: options.slice(:only, :except, :cocina).none?) unless options[:skip_update]
     abort 'ABORTING: multiple versions of the cocina-models gem are in use' unless CocinaChecker.check
 
-    Deployer.deploy(environment: options[:environment], repos: repositories, tag: options[:tag])
+    Deployer.deploy(
+      environment: options[:environment],
+      repos: repositories,
+      tag: options[:tag],
+      before_command: options[:before_command]
+    )
   end
 end
 


### PR DESCRIPTION
## Why was this change made?

This helps us with the default gem conundrum. Usage in this context is documented in the README.



## How was this change tested?

Run against all envs to install the strscan gem.

## Which documentation and/or configurations were updated?

README
