### PR TITLE
Adds support for non-standard prod environments.

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,12 +89,15 @@ Example:
   bin/sdr deploy -s -e qa --only sul-dlss/technical-metadata-service sul-dlss/argo
 ```
 
-**NOTE 1**: We have a couple applications that use environments outside of our standard ones (qa, prod, and stage), and sdr-deploy deploys to these oddball environments when deploying to QA. These are configured on a per-application basis in `config/settings.yml` via, e.g.:
+**NOTE 1**: We have a couple applications that use environments outside of our standard ones (qa, prod, and stage), and sdr-deploy deploys to these oddball environments when deploying to QA or prod. These are configured on a per-application basis in `config/settings.yml` via, e.g.:
 
 ```yaml
   - name: sul-dlss/sul_pub
-    non_standard_envs:
+    non_standard_qa_envs:
       - cap-dev
+  - name: sul-dlss/technical-metadata-service
+    non_standard_prod_envs:
+      - retro
 ```
 
 **NOTE 2**: Sometimes we want to be extra careful when deploying certain apps to certain environments. These are configured on a per-application basis in `config/settings.yml` via, e.g.:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -22,7 +22,7 @@ repositories:
     cocina_models_update: true
   - name: sul-dlss/hydra_etd
     cocina_models_update: true
-    non_standard_envs:
+    non_standard_qa_envs:
       - uat
   - name: sul-dlss/ksr-app
   - name: sul-dlss/modsulator-app-rails
@@ -34,10 +34,12 @@ repositories:
   - name: sul-dlss/sdr-api
     cocina_models_update: true
   - name: sul-dlss/sul_pub
-    non_standard_envs:
+    non_standard_qa_envs:
       - cap-dev
   - name: sul-dlss/suri-rails
   - name: sul-dlss/technical-metadata-service
+    non_standard_prod_envs:
+      - retro
   - name: sul-dlss/was-pywb
   - name: sul-dlss/was-registrar-app
     cocina_models_update: true

--- a/lib/sdr_deploy.rb
+++ b/lib/sdr_deploy.rb
@@ -17,6 +17,7 @@ Config.load_and_set_settings(
 
 # Common methods
 # rubocop: disable Metrics/MethodLength
+# rubocop: disable Metrics/AbcSize
 def within_project_dir(repo:, environment: nil, &block)
   results = []
 
@@ -31,16 +32,21 @@ def within_project_dir(repo:, environment: nil, &block)
       ENV['BUNDLE_GEMS__CONTRIBSYS__COM'] = contribsys_credentials
       results << block.call(environment)
 
-      # Some of our apps use non-standard envs and by convention we deploy these when deploying QA
-      return results unless environment == 'qa' && repo.non_standard_envs
+      # Some of our apps use non-standard envs
+      if environment == 'qa' && repo.non_standard_qa_envs
+        repo.non_standard_qa_envs.each { |env| results << block.call(env) }
+      end
 
-      repo.non_standard_envs.each { |env| results << block.call(env) }
+      if environment == 'prod' && repo.non_standard_prod_envs
+        repo.non_standard_prod_envs.each { |env| results << block.call(env) }
+      end
 
       results
     end
   end
 end
 # rubocop: enable Metrics/MethodLength
+# rubocop: enable Metrics/AbcSize
 
 def colorize_failure(string)
   pastel.white.on_bright_red.bold(string)


### PR DESCRIPTION
## Why was this change made?
Support techmd `retro` environment, which is a non-standard production environment.


## How was this change tested?



## Which documentation and/or configurations were updated?



