### PR TITLE
gis-robot-suite IS a direct cocina consumer

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -16,6 +16,7 @@ repositories:
   - name: sul-dlss/dor_indexing_app
     cocina_models_update: true
   - name: sul-dlss/gis-robot-suite
+    cocina_models_update: true
   - name: sul-dlss/google-books
     cocina_models_update: true
   - name: sul-dlss/happy-heron


### PR DESCRIPTION
## Why was this change made?

Because gis-robot-suite is now a direct cocina-models consumer, and should be deployed when other cocina-models affected apps are deployed.

## How was this change tested?



## Which documentation and/or configurations were updated?



