### PR TITLE
allow cocina-models to be checked for a tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,11 +38,21 @@ NOTE: Watch the output for any errors
 
 ### Check versions of cocina-models
 
-```shell
-bin/sdr check_cocina
+```
+Usage:
+  sdr check_cocina
+
+Options:
+  -s, [--skip-update], [--no-skip-update]  # Skip update repos
+  -t, [--tag=TAG]                          # Check cocina version for the given tag instead of the default branch
+
+check for cocina-models version mismatches
+
+Examples:
+  bin/sdr check_ssh -s -t rel-2022-08-01
 ```
 
-This will let you know which versions of cocina-models each project is locked to.
+This will let you know which versions of cocina-models are used by each project with it in Gemfile.lock.
 
 ### Create repository tags
 
@@ -78,7 +88,7 @@ Options:
       [--except=one two three]             # Update all except these repos
   -c, [--cocina], [--no-cocina]            # Only update repos affected by new cocina-models gem release
   -b, [--before-command=BEFORE_COMMAND]    # Run this command on each host before deploying
-  -t, [--tag=TAG]                          # Deploy the given tag instead of the main branch
+  -t, [--tag=TAG]                          # Deploy the given tag instead of the default branch
   -s, [--skip-update], [--no-skip-update]  # Skip update repos
   -e, --environment=ENVIRONMENT            # Deployment environment
                                            # Possible values: qa, prod, stage

--- a/bin/sdr
+++ b/bin/sdr
@@ -11,10 +11,21 @@ class CLI < Thor
     true
   end
 
+  option :skip_update,
+         type: :boolean,
+         default: false,
+         desc: 'Skip update repos',
+         aliases: '-s'
+  option :tag,
+         type: :string,
+         desc: 'Check cocina version for the given tag instead of the default branch',
+         aliases: '-t'
+
   desc 'check_cocina', 'check for cocina-models version mismatches'
   def check_cocina
-    RepoUpdater.update(repos: Settings.repositories)
-    CocinaChecker.check
+    repositories = Settings.repositories.select(&:cocina_models_update)
+    RepoUpdater.update(repos: repositories) unless options[:skip_update]
+    CocinaChecker.check(repos: repositories, tag: options[:tag])
   end
 
   option :message,
@@ -106,7 +117,7 @@ class CLI < Thor
          aliases: '-b'
   option :tag,
          type: :string,
-         desc: 'Deploy the given tag instead of the main branch',
+         desc: 'Deploy the given tag instead of the default branch',
          aliases: '-t'
   option :skip_update,
          type: :boolean,
@@ -137,7 +148,8 @@ class CLI < Thor
 
     # Do not prune repos if operating on a subset of repos else legitimate current repos get unnecessarily pruned
     RepoUpdater.update(repos: repositories, prune: options.slice(:only, :except, :cocina).none?) unless options[:skip_update]
-    abort 'ABORTING: multiple versions of the cocina-models gem are in use' unless CocinaChecker.check
+    cocina_repos = Settings.repositories.select(&:cocina_models_update)
+    abort 'ABORTING: multiple versions of the cocina-models gem are in use' unless CocinaChecker.check(repos: cocina_repos, tag: options[:tag])
 
     Deployer.deploy(
       environment: options[:environment],


### PR DESCRIPTION
## Why was this change made?

When deploying, we should be checking the cocina version consistentcy of the released tag.  

We still want to be able to check the default (main) branch.

Fixes #146 

## How was this change tested?

I ran the command with all the different options

## Which documentation and/or configurations were updated?

README is updated.

