### PR TITLE
CocinaChecker#switch_repo_to_tag - shell out in a Dir.chdir block 

### DIFF
--- a/lib/cocina_checker.rb
+++ b/lib/cocina_checker.rb
@@ -93,12 +93,13 @@ class CocinaChecker
 
   # git checkout repo to the given tag, or switch to default branch if none
   def switch_repo_to_tag(lockfile_path, target)
-    Dir.chdir(lockfile_path.delete_suffix('/Gemfile.lock'))
-    if target
-      # it's fine for this to be a detached HEAD
-      `git checkout #{target} -q -d`
-    else
-      `git switch -q -`
+    Dir.chdir(lockfile_path.delete_suffix('/Gemfile.lock')) do
+      if target
+        # it's fine for this to be a detached HEAD
+        `git checkout #{target} -q -d`
+      else
+        `git switch -q -`
+      end
     end
   end
 end


### PR DESCRIPTION
## Why was this change made?

so that the working directory isn't left changed going forward

this got me slightly nicer output in the new mode when i tested:

before:

```
sdr-deploy % bin/sdr check_cocina -t rel-2022-08-01
Updating cached git repository [▣▣▣▣▣▣▣▣▣▣▣▣] (12/12, ETA:  0s) sul-dlss/was_robot_suite   
repos to Cocina check: sul-dlss/argo, sul-dlss/common-accessioning, sul-dlss/dor-services-app, sul-dlss/dor_indexing_app, sul-dlss/gis-robot-suite, sul-dlss/google-books, sul-dlss/happy-heron, sul-dlss/hydra_etd, sul-dlss/pre-assembly, sul-dlss/sdr-api, sul-dlss/was-registrar-app, sul-dlss/was_robot_suite
------- COCINA REPORT -------
  for tag rel-2022-08-01 of repos
Found these versions of cocina in use:
  0.83.0
    /Users/jmartin-sul/software_dev_projects/sdr-deploy/tmp/repos/sul-dlss/argo
    /Users/jmartin-sul/software_dev_projects/sdr-deploy/tmp/repos/sul-dlss/common-accessioning
    /Users/jmartin-sul/software_dev_projects/sdr-deploy/tmp/repos/sul-dlss/dor-services-app
    /Users/jmartin-sul/software_dev_projects/sdr-deploy/tmp/repos/sul-dlss/dor_indexing_app
    /Users/jmartin-sul/software_dev_projects/sdr-deploy/tmp/repos/sul-dlss/gis-robot-suite
    /Users/jmartin-sul/software_dev_projects/sdr-deploy/tmp/repos/sul-dlss/google-books
    /Users/jmartin-sul/software_dev_projects/sdr-deploy/tmp/repos/sul-dlss/happy-heron
    /Users/jmartin-sul/software_dev_projects/sdr-deploy/tmp/repos/sul-dlss/hydra_etd
    /Users/jmartin-sul/software_dev_projects/sdr-deploy/tmp/repos/sul-dlss/pre-assembly
    /Users/jmartin-sul/software_dev_projects/sdr-deploy/tmp/repos/sul-dlss/sdr-api
    /Users/jmartin-sul/software_dev_projects/sdr-deploy/tmp/repos/sul-dlss/was-registrar-app
    /Users/jmartin-sul/software_dev_projects/sdr-deploy/tmp/repos/sul-dlss/was_robot_suite
sdr-deploy %
```

after:

```
sdr-deploy % bin/sdr check_cocina -t rel-2022-08-01                              main
Updating cached git repository [▣▣▣▣▣▣▣▣▣▣▣▣] (12/12, ETA:  0s) sul-dlss/was_robot_suite   
repos to Cocina check: sul-dlss/argo, sul-dlss/common-accessioning, sul-dlss/dor-services-app, sul-dlss/dor_indexing_app, sul-dlss/gis-robot-suite, sul-dlss/google-books, sul-dlss/happy-heron, sul-dlss/hydra_etd, sul-dlss/pre-assembly, sul-dlss/sdr-api, sul-dlss/was-registrar-app, sul-dlss/was_robot_suite
------- COCINA REPORT -------
  for tag rel-2022-08-01 of repos
Found these versions of cocina in use:
  0.83.0
    sul-dlss/argo
    sul-dlss/common-accessioning
    sul-dlss/dor-services-app
    sul-dlss/dor_indexing_app
    sul-dlss/gis-robot-suite
    sul-dlss/google-books
    sul-dlss/happy-heron
    sul-dlss/hydra_etd
    sul-dlss/pre-assembly
    sul-dlss/sdr-api
    sul-dlss/was-registrar-app
    sul-dlss/was_robot_suite
sdr-deploy %
```


see https://github.com/sul-dlss/sdr-deploy/pull/150#discussion_r935053298

## How was this change tested?

ran `bin/sdr check_cocina` and `bin/sdr check_cocina -t rel-2022-08-01`

## Which documentation and/or configurations were updated?

n/a