### PR TITLE
Document that Ruby 3.1 is required

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This is a central place for deploying applications in the Infrastructure team portfolio, primarily but not exclusively related to the Stanford Digital Repository (SDR). This allows all applications to be deployed together with a single set of tools.
 
+## Requirements
+
+sdr-deploy expects Ruby 3.1.
+
 ## Usage
 
 Make sure that:


### PR DESCRIPTION
## Why was this change made?

Because the codebase now uses Ruby 3.1 syntax so we should document this requirement.

## How was this change tested?

N/A

## Which documentation and/or configurations were updated?

README
