### PR TITLE
Add support for skipping deploy to environments. Sets H2 prod to skip…

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,14 @@ Or you can update a gem for a specific app like this:
       - prod
 ```
 
+**NOTE 4**: Sometimes we want to skip deploying to certain environments. These are configured on a per-application basis in `config/settings.yml` via, e.g.:
+
+```yaml
+  - name: sul-dlss/happy-heron
+    skip_envs:
+      - prod
+```
+
 ### Only Deploy Repos Related to Cocina-Models Update
 
 Note: this includes dor-services-app and sdr-api in addition to cocina level2 updates.

--- a/bin/sdr
+++ b/bin/sdr
@@ -146,8 +146,10 @@ class CLI < Thor
       repositories.reject! { |repo| options[:except].include?(repo.name) }
     end
 
+    repositories.reject! { |repo| Array(repo.skip_envs).include?(options[:environment]) }
+
     # Do not prune repos if operating on a subset of repos else legitimate current repos get unnecessarily pruned
-    RepoUpdater.update(repos: repositories, prune: options.slice(:only, :except, :cocina).none?) unless options[:skip_update]
+    RepoUpdater.update(repos: repositories, prune: options.slice(:only, :except, :cocina, :skip_envs).none?) unless options[:skip_update]
     cocina_repos = Settings.repositories.select(&:cocina_models_update)
     abort 'ABORTING: multiple versions of the cocina-models gem are in use' unless CocinaChecker.check(repos: cocina_repos, tag: options[:tag])
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -21,6 +21,8 @@ repositories:
     cocina_models_update: true
   - name: sul-dlss/happy-heron
     cocina_models_update: true
+    skip_envs:
+      - prod
   - name: sul-dlss/hydra_etd
     cocina_models_update: true
     non_standard_qa_envs:


### PR DESCRIPTION
… deploy.

## Why was this change made?
Prevent H2 prod deploys.


## How was this change tested?
Local


## Which documentation and/or configurations were updated?
README


