### PR TITLE
remove confirmation to deploy argo from 10 months ago

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -7,8 +7,6 @@ supported_envs:
 repositories:
   - name: sul-dlss/argo
     cocina_models_update: true
-    confirmation_required_envs:
-      - prod
   - name: sul-dlss/common-accessioning
     cocina_models_update: true
   - name: sul-dlss/dor-services-app


### PR DESCRIPTION
## Why was this change made?

we no longer need confirmation like this to deploy argo.

## How was this change tested?

unit tests

## Which documentation and/or configurations were updated?

settings.yml

