### PR TITLE
temporarily skip sul-pub UAT environment so we can test branch

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -32,8 +32,10 @@ repositories:
   - name: sul-dlss/sdr-api
     cocina_models_update: true
   - name: sul-dlss/sul_pub
-    non_standard_envs:
-      - uat
+    # Note: August 17 2023 This is temporarily disabled so we can test a branch on UAT.
+    # see https://github.com/sul-dlss/sul_pub/issues/1618
+    # non_standard_envs:
+    #   - uat
   - name: sul-dlss/suri-rails
   - name: sul-dlss/technical-metadata-service
   - name: sul-dlss/was-pywb


### PR DESCRIPTION
## Why was this change made?

See https://github.com/sul-dlss/sul_pub/issues/1618 ... we want to test a branch of sul-pub on UAT and so not want to deploy dependency updates there while we do this.  We will revert then when done with testing.
