### PR TITLE
Revert "temporarily skip sul-pub UAT environment so we can test branch"

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -32,10 +32,8 @@ repositories:
   - name: sul-dlss/sdr-api
     cocina_models_update: true
   - name: sul-dlss/sul_pub
-    # Note: August 17 2023 This is temporarily disabled so we can test a branch on UAT.
-    # see https://github.com/sul-dlss/sul_pub/issues/1618
-    # non_standard_envs:
-    #   - uat
+    non_standard_envs:
+      - uat
   - name: sul-dlss/suri-rails
   - name: sul-dlss/technical-metadata-service
   - name: sul-dlss/was-pywb


### PR DESCRIPTION
Reverts sul-dlss/sdr-deploy#220

WoS API branch of sul-pub is now merged and we can deploy everywhere again.