### PR TITLE
CocinaChecker#check_cocina: unique_major_minors becomes a more accurate var name

### DIFF
--- a/lib/cocina_checker.rb
+++ b/lib/cocina_checker.rb
@@ -40,9 +40,9 @@ class CocinaChecker
 
     unique_major_minors = unique_values.keys.map do |version_string|
       version_string.split('.')[0..1].join('.')
-    end
+    end.uniq
 
-    return false if unique_major_minors.uniq.size > 1
+    return false if unique_major_minors.size > 1
 
     TTY::Prompt.new.yes?('Found divergence in cocina-models patch-level versions. Continue with deploy?') do |prompt|
       prompt.default(true)


### PR DESCRIPTION
## Why was this change made?

i am a nitpicky programmer with a lack of self control.

## How was this change tested?

```
% bin/sdr check_cocina
Updating cached git repository [▣▣▣▣▣▣▣▣▣▣▣▣] (12/12, ETA:  0s) sul-dlss/was-registrar-app 
repos to Cocina check: sul-dlss/argo, sul-dlss/common-accessioning, sul-dlss/dor-services-app, sul-dlss/dor_indexing_app, sul-dlss/gis-robot-suite, sul-dlss/google-books, sul-dlss/happy-heron, sul-dlss/hydra_etd, sul-dlss/pre-assembly, sul-dlss/sdr-api, sul-dlss/was-registrar-app, sul-dlss/was_robot_suite
------- COCINA REPORT -------
  for default branches of repos
Found these versions of cocina in use:
	0.94.0
		sul-dlss/argo
		sul-dlss/common-accessioning
		sul-dlss/google-books
		sul-dlss/happy-heron
		sul-dlss/hydra_etd
		sul-dlss/pre-assembly
		sul-dlss/sdr-api
		sul-dlss/was-registrar-app
		sul-dlss/was_robot_suite
	0.94.1
		sul-dlss/gis-robot-suite
	0.94.2
		sul-dlss/dor-services-app
		sul-dlss/dor_indexing_app
Found divergence in cocina-models patch-level versions. Continue with deploy? (Y/n) 
```

## Which documentation and/or configurations were updated?

n/a