### PR TITLE
Remove bundle exec from cap command.

### DIFF
--- a/lib/deployer.rb
+++ b/lib/deployer.rb
@@ -136,7 +136,7 @@ class Deployer
   def deploy(env)
     output = []
 
-    IO.popen({ 'SKIP_BUNDLE_AUDIT' => 'true' }, "bundle exec cap #{env} deploy 2>&1") do |f|
+    IO.popen({ 'SKIP_BUNDLE_AUDIT' => 'true' }, "cap #{env} deploy 2>&1") do |f|
       loop do
         output << f.readline
         # NOTE: Uncomment this if the deploy does something mysterious and you crave more observability.


### PR DESCRIPTION
## Why was this change made?
So that deploy with work with OS X 14.4


## How was this change tested?
Local


## Which documentation and/or configurations were updated?



