### PR TITLE
Add ability to deploy & check specified branches in addition to tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,12 +48,13 @@ Usage:
 
 Options:
   -s, [--skip-update], [--no-skip-update]  # Skip update repos
-  -t, [--tag=TAG]                          # Check cocina version for the given tag instead of the default branch
+  -t, --branch, [--tag=TAG]                # Check cocina version in the given tag or branch instead of the default branch
 
 check for cocina-models version mismatches
 
 Example:
-  bin/sdr check_cocina -t rel-2022-08-01
+  bin/sdr check_cocina -s -t rel-2022-08-01
+  bin/sdr check_cocina -t my-wip-branch
 ```
 
 This will let you know which versions of cocina-models are used by each project with it in Gemfile.lock.
@@ -93,7 +94,7 @@ Options:
       [--except=one two three]             # Update all except these repos
   -c, [--cocina], [--no-cocina]            # Only update repos affected by new cocina-models gem release
   -b, [--before-command=BEFORE_COMMAND]    # Run this command on each host before deploying
-  -t, [--tag=TAG]                          # Deploy the given tag instead of the default branch
+  -t, --branch, [--tag=TAG]                # Deploy the given tag or branch instead of the default branch
   -s, [--skip-update], [--no-skip-update]  # Skip update repos
   -e, --environment=ENVIRONMENT            # Deployment environment
                                            # Possible values: qa, prod, stage
@@ -101,7 +102,7 @@ Options:
 deploy all the services in an environment
 
 Examples:
-  bin/sdr deploy -s -e qa -t rel-2022-06-06 --only sul-dlss/technical-metadata-service sul-dlss/argo
+  bin/sdr deploy -s -e qa -t my-wip-branch --only=sul-dlss/technical-metadata-service
   bin/sdr deploy -c -e qa -t rel-2022-09-14
 ```
 

--- a/bin/sdr
+++ b/bin/sdr
@@ -18,9 +18,8 @@ class CLI < Thor
          aliases: '-s'
   option :tag,
          type: :string,
-         desc: 'Check cocina version for the given tag instead of the default branch',
-         aliases: '-t'
-
+         desc: 'Check cocina version in the given tag or branch instead of the default branch',
+         aliases: ['-t', '--branch']
   desc 'check_cocina', 'check for cocina-models version mismatches'
   def check_cocina
     repositories = Settings.repositories.select(&:cocina_models_update)
@@ -45,7 +44,6 @@ class CLI < Thor
          default: false,
          desc: 'Only tag repos affected by new cocina-models gem release',
          aliases: '-c'
-
   desc 'tag TAG_NAME', 'create or delete a tag named TAG_NAME'
   def tag(tag_name)
     repositories = if options[:cocina]
@@ -117,8 +115,8 @@ class CLI < Thor
          aliases: '-b'
   option :tag,
          type: :string,
-         desc: 'Deploy the given tag instead of the default branch',
-         aliases: '-t'
+         desc: 'Deploy the given tag or branch instead of the default branch',
+         aliases: ['-t', '--branch']
   option :skip_update,
          type: :boolean,
          default: false,

--- a/lib/cocina_checker.rb
+++ b/lib/cocina_checker.rb
@@ -103,15 +103,29 @@ class CocinaChecker
       .transform_values { |value| value.map(&:first) }
   end
 
-  # git checkout repo to the given tag, or switch to default branch if none
+  # git checkout repo to the given tag/branch, or switch to default branch if none
   def switch_repo_to_tag(lockfile_path, target)
     Dir.chdir(lockfile_path.delete_suffix('/Gemfile.lock')) do
-      if target
+      if tag?(target)
         # it's fine for this to be a detached HEAD
         `git checkout #{target} -q -d`
+      elsif branch?(target)
+        `git switch -q #{target}`
       else
         `git switch -q -`
       end
     end
+  end
+
+  def branch?(target)
+    return false unless target
+
+    system("git show-ref -q --verify refs/remotes/origin/#{target}")
+  end
+
+  def tag?(target)
+    return false unless target
+
+    system("git show-ref -q --verify refs/tags/#{target}")
   end
 end

--- a/lib/deployer.rb
+++ b/lib/deployer.rb
@@ -125,7 +125,7 @@ class Deployer
 
   def repos_missing_tag
     @repos_missing_tag ||= repos.reject do |repo|
-      Dir.chdir(RepoUpdater.new(repo:).repo_dir) { `git tag`.split.include?(tag) }
+      Dir.chdir(RepoUpdater.new(repo:).repo_dir) { system("git show-ref -q #{tag}") }
     end.map(&:name)
   end
 


### PR DESCRIPTION
# Why was this change made?

The SDR VMs will soon have MFA turned on for SSH in all environments. We have a solution for weekly mass deploys in place already that uses `sdr-infra` as a jump host, but currently if a developer needs to deploy a single branch for a single repo via capistrano, that requires N * M SSH connections: N being the number of VMs in a given environment and M being the number of steps in the capistrano deployment. Each of these connections will require a separate MFA interaction---which is untenable.

 This commit lets us extend our jump host solution to one-off deploys of codebases by allowing `sdr-deploy` to deal with both tags *and* branches.

# How was this change tested?

Did a couple deploys.
