### PR TITLE
Change how git repositories are cloned to allow remote branches

### DIFF
--- a/lib/repo_updater.rb
+++ b/lib/repo_updater.rb
@@ -68,7 +68,7 @@ class RepoUpdater
   def create_repo
     FileUtils.mkdir_p(repo_dir)
     within_project_dir(repo:) do
-      ErrorEmittingExecutor.execute("git clone --depth=5 --tags git@github.com:#{repo.name}.git .", exit_on_error: true)
+      ErrorEmittingExecutor.execute("git clone --tags git@github.com:#{repo.name}.git .", exit_on_error: true)
       ErrorEmittingExecutor.execute('git fetch --tags origin', exit_on_error: true)
       ErrorEmittingExecutor.execute('bundle install')
     end


### PR DESCRIPTION
# Why was this change made?

Because `git clone` used to include the `--depth` argument, the `fetch` git config was set up to *only* fetch `main`, so the git configuration was prohibiting us from being able to verify remote branches. This fixes that.

This work is in support of our push to enable MFA.

# How was this change tested?

Deploys.
