### PR TITLE
Remove launchy

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,6 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
 gem 'byebug'
 gem 'config', '~> 3.1'
-gem 'launchy', '~> 2.5'
 gem 'parallel', '~> 1.21'
 gem 'pastel', '~> 0.8'
 gem 'rubocop', '~> 1.24'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,6 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.8.6)
-      public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
     bigdecimal (3.1.7)
     byebug (11.1.3)
@@ -46,15 +44,12 @@ GEM
       zeitwerk (~> 2.6)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
-    launchy (2.5.2)
-      addressable (~> 2.8)
     parallel (1.24.0)
     parser (3.3.0.5)
       ast (~> 2.4.1)
       racc
     pastel (0.8.0)
       tty-color (~> 0.5)
-    public_suffix (5.0.4)
     racc (1.7.3)
     rainbow (3.1.1)
     regexp_parser (2.9.0)
@@ -118,7 +113,6 @@ PLATFORMS
 DEPENDENCIES
   byebug
   config (~> 3.1)
-  launchy (~> 2.5)
   parallel (~> 1.21)
   pastel (~> 0.8)
   rspec_junit_formatter

--- a/lib/deployer.rb
+++ b/lib/deployer.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'English'
-require 'launchy'
 
 # Service class for deploying
 # rubocop:disable Metrics/ClassLength
@@ -64,8 +63,7 @@ class Deployer
       puts "Output from failed deployment of #{result.repo} (#{result.env}):\n#{result.output}"
     end
 
-    puts "Deployments to #{environment} complete. Opening #{status_url} in your browser so you can check statuses"
-    Launchy.open(status_url)
+    puts "Deployments to #{environment} complete. Open #{status_url} to check service status."
   end
 
   def ensure_tag_present_in_all_repos!


### PR DESCRIPTION
## Why was this change made?

Now that we are deploying in a terminal on sdr-infra.stanford.edu the
launching of a browser pointed at nagios doesn't seem to work. I get
prompted for a cookie, and then when I answer "Y" it doesn't seem to
work. This commit prints the URL for clicking on instead.

<img width="1586" alt="Screenshot 2024-03-25 at 1 38 42 PM" src="https://github.com/sul-dlss/sdr-deploy/assets/33829/4a4fdff9-f224-4f30-b4b5-e28921de1f05">

After:

<img width="1586" alt="Screenshot 2024-03-25 at 1 45 17 PM" src="https://github.com/sul-dlss/sdr-deploy/assets/33829/3b92a171-9fb9-4bc9-b51c-39d84aaf48dd">

## How was this change tested?

I ran a `bin/sdr deploy` to stage.

## Which documentation and/or configurations were updated?

None.



