### PR TITLE
Tweak the progress bar style

### DIFF
--- a/lib/deployer.rb
+++ b/lib/deployer.rb
@@ -19,7 +19,7 @@ class Deployer
     @repos = repos
     @progress_bar = TTY::ProgressBar.new(
       'Deploying [:bar] (:current/:total, ETA: :eta) :repo',
-      bar_format: :crate,
+      bar_format: :box,
       total: @repos.count
     )
     @tag = tag

--- a/lib/repo_updater.rb
+++ b/lib/repo_updater.rb
@@ -18,7 +18,7 @@ class RepoUpdater
   def self.progress_bar(repos)
     TTY::ProgressBar.new(
       'Updating cached git repository [:bar] (:current/:total, ETA: :eta) :repo',
-      bar_format: :crate,
+      bar_format: :box,
       total: repos.count
     )
   end


### PR DESCRIPTION
This commit slightly tweaks the progress bar style when deploying and updating repos.

# Why was this change made?

It looks better to me, at least?

## Before

![progress_bar_crates](https://github.com/sul-dlss/sdr-deploy/assets/131982/5f32bdf2-62cb-464d-866c-bb9f3ef792a7)

## After

![progress_bar_boxes](https://github.com/sul-dlss/sdr-deploy/assets/131982/4c7b046f-991f-40f6-894b-2bb04a35c3e3)
