### PR TITLE
Stop deploying DIA

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -11,8 +11,6 @@ repositories:
     cocina_models_update: true
   - name: sul-dlss/dor-services-app
     cocina_models_update: true
-  - name: sul-dlss/dor_indexing_app
-    cocina_models_update: true
   - name: sul-dlss/gis-robot-suite
     cocina_models_update: true
   - name: sul-dlss/google-books


### PR DESCRIPTION
## Why was this change made?
No longer needs to be deployed.


## How was this change tested?



## Which documentation and/or configurations were updated?



