### PR TITLE
log success output from ssh checking and deploying

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 tmp/
+*.local.yml

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Make sure that:
   * The credentials are set to an environment variable on the server via puppet from values stored in vault (vault info: https://consul.stanford.edu/display/systeam/Vault+for+Developers).  To fetch without digging into vault, go to a server that has them set via puppet and view the environment variable. See below under "Configure bundler for your local path" for an example.
 * NOTE: You *may* invoke the `bin/` scripts via `bundle exec`.
 
-Success output for repo cache updates and deploys is logged to 'tmp/progress.log'.  This is useful if you get a crash part way, as it can tell you which repos were successfully completed.
+You can turn on success output for repo cache updates and deploy logging if you find it useful.  Override the Settings.progress_file in a config/settings.local.yml and you will get one file per repo.  This is useful if you get a crash part way, as it can tell you which repos were successfully completed.
 
 ### SSH Setup
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Make sure that:
   * The credentials are set to an environment variable on the server via puppet from values stored in vault (vault info: https://consul.stanford.edu/display/systeam/Vault+for+Developers).  To fetch without digging into vault, go to a server that has them set via puppet and view the environment variable. See below under "Configure bundler for your local path" for an example.
 * NOTE: You *may* invoke the `bin/` scripts via `bundle exec`.
 
+Success output for repo cache updates and deploys is logged to 'tmp/progress.log'.  This is useful if you get a crash part way, as it can tell you which repos were successfully completed.
+
 ### SSH Setup
 
 Follow the [GitHub Documentation](https://docs.github.com/en/authentication/connecting-to-github-with-ssh) if you need to establish new SSH keys.

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,6 +1,8 @@
 work_dir: tmp/repos
 num_parallel_processes: 4
-progress_file: 'tmp/progress.log'
+progress_file:
+  enabled: false # enable to log one file per repo in the location specified below
+  location: 'tmp'
 supported_envs:
   qa: https://sul-nagios-stage.stanford.edu/nagios/cgi-bin/status.cgi?hostgroup=infrastructure-qa&style=detail&servicestatustypes=28&hoststatustypes=15
   prod: https://sul-nagios-prod.stanford.edu/nagios/cgi-bin/status.cgi?hostgroup=infrastructure-prod&style=detail&servicestatustypes=28&hoststatustypes=15

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,5 +1,6 @@
 work_dir: tmp/repos
 num_parallel_processes: 4
+progress_file: 'tmp/progress.log'
 supported_envs:
   qa: https://sul-nagios-stage.stanford.edu/nagios/cgi-bin/status.cgi?hostgroup=infrastructure-qa&style=detail&servicestatustypes=28&hoststatustypes=15
   prod: https://sul-nagios-prod.stanford.edu/nagios/cgi-bin/status.cgi?hostgroup=infrastructure-prod&style=detail&servicestatustypes=28&hoststatustypes=15

--- a/lib/deployer.rb
+++ b/lib/deployer.rb
@@ -35,8 +35,11 @@ class Deployer
     results = Parallel.map(
       repos,
       in_processes: Settings.num_parallel_processes,
-      finish: ->(repo, _i, _result) { progress_bar.advance(repo: repo.name) }
-    ) do |repo|
+      finish: ->(repo, _i, _result) do
+        File.open(Settings.progress_file, 'a') { |f| f.write("#{Time.now} : #{repo.name} deploy complete\n") }
+        progress_bar.advance(repo: repo.name)
+      end
+      ) do |repo|
       within_project_dir(repo:, environment:) do |env|
         auditor.audit(repo: repo.name)
         run_before_command!(env)

--- a/lib/deployer.rb
+++ b/lib/deployer.rb
@@ -28,6 +28,7 @@ class Deployer
     prompt_user_for_approval_confirmation!
   end
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   def deploy_all
     puts "Repositories: #{repos.map(&:name).join(', ')}"
     progress_bar.start
@@ -35,11 +36,14 @@ class Deployer
     results = Parallel.map(
       repos,
       in_processes: Settings.num_parallel_processes,
-      finish: ->(repo, _i, _result) do
-        File.open(Settings.progress_file, 'a') { |f| f.write("#{Time.now} : #{repo.name} deploy complete\n") }
+      finish: lambda do |repo, _i, _result|
+        if Settings.progress_file.enabled
+          filename = File.join(Settings.progress_file.location, "#{File.basename(repo.name)}-deploy.log")
+          File.write(filename, "#{Time.now} : #{repo.name} deploy complete")
+        end
         progress_bar.advance(repo: repo.name)
       end
-      ) do |repo|
+    ) do |repo|
       within_project_dir(repo:, environment:) do |env|
         auditor.audit(repo: repo.name)
         run_before_command!(env)
@@ -68,6 +72,7 @@ class Deployer
 
     puts "Deployments to #{environment} complete. Open #{status_url} to check service status."
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 
   def ensure_tag_present_in_all_repos!
     return if repos_missing_tag.empty?

--- a/lib/repo_updater.rb
+++ b/lib/repo_updater.rb
@@ -10,7 +10,10 @@ class RepoUpdater
     Parallel.each(
       repos,
       in_processes: Settings.num_parallel_processes,
-      finish: ->(repo, _i, _result) { @progress_bar.advance(repo: repo.name) }
+      finish: ->(repo, _i, _result) do
+        File.open(Settings.progress_file, 'a') { |f| f.write("#{Time.now} : #{repo.name} repo update complete\n") }
+        @progress_bar.advance(repo: repo.name)
+      end
     ) { |repo| new(repo:).update_or_create_repo }
     prune_removed_repos_from_cache!(repos) if prune
   end


### PR DESCRIPTION
## Why was this change made?

Allows us to see when a repo has been successfully updated or deployed in a log file.  Useful when the parallel processes fail part without useful output telling you which repo may have caused the problem.

## How was this change tested?

Localhost with an update and a deploy

## Which documentation and/or configurations were updated?

README updated


