### PR TITLE
Add a refresh_repos method and update rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -200,3 +200,26 @@ Style/RedundantLineContinuation: # new in 1.49
   Enabled: true
 Style/RedundantRegexpConstructor: # new in 1.52
   Enabled: true
+
+Lint/ItWithoutArgumentsInBlock: # new in 1.59
+  Enabled: true
+Lint/LiteralAssignmentInCondition: # new in 1.58
+  Enabled: true
+Lint/MixedCaseRange: # new in 1.53
+  Enabled: true
+Lint/RedundantRegexpQuantifiers: # new in 1.53
+  Enabled: true
+Style/MapIntoArray: # new in 1.63
+  Enabled: true
+Style/RedundantCurrentDirectoryInPath: # new in 1.53
+  Enabled: true
+Style/RedundantRegexpArgument: # new in 1.53
+  Enabled: true
+Style/ReturnNilInPredicateMethodDefinition: # new in 1.53
+  Enabled: true
+Style/SingleLineDoEndBlock: # new in 1.57
+  Enabled: true
+Style/SuperWithArgsParentheses: # new in 1.58
+  Enabled: true
+Style/YAMLFileRead: # new in 1.53
+  Enabled: true

--- a/bin/sdr
+++ b/bin/sdr
@@ -158,6 +158,19 @@ class CLI < Thor
       before_command: options[:before_command]
     )
   end
+
+  option :only,
+         type: :array,
+         default: [],
+         desc: 'Update only these repos'
+  option :except,
+         type: :array,
+         default: [],
+         desc: 'Update all except these repos'
+  desc 'refresh_repos', 'refresh the local repos'
+  def refresh_repos
+    RepoUpdater.update(repos: Settings.repositories, prune: options.slice(:only, :except).none?)
+  end
 end
 
 CLI.start(ARGV)

--- a/lib/deployer.rb
+++ b/lib/deployer.rb
@@ -157,7 +157,7 @@ class Deployer
     else
       # Forces the `git:create_release` cap task to use the HEAD ref, which allows
       # different repositories to use different default branches.
-      text.sub!(/ask :branch/, 'set :branch')
+      text.sub!('ask :branch', 'set :branch')
     end
 
     File.write('config/deploy.rb', text)


### PR DESCRIPTION
## Why was this change made?

I have found being able to update the repositories at once to search for code throughout our stack to be helpful. This allows me to refresh the repositories without having to use check_ssh/deploy/etc.

## How was this change tested?



## Which documentation and/or configurations were updated?



