### PR TITLE
Add exclude repos to support dlme-airflow

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -12,6 +12,13 @@ repositories:
     cocina_models_update: true
   - name: sul-dlss/common-accessioning
     cocina_models_update: true
+  - name: sul-dlss/dlme-airflow
+    non_standard_envs:
+      - dev
+    exclude_envs:
+      - prod
+      - stage
+      - qa
   - name: sul-dlss/dor-services-app
     cocina_models_update: true
   - name: sul-dlss/gis-robot-suite

--- a/lib/sdr_deploy.rb
+++ b/lib/sdr_deploy.rb
@@ -29,7 +29,7 @@ def within_project_dir(repo:, environment: nil, &block)
     contribsys_credentials = ENV.fetch('BUNDLE_GEMS__CONTRIBSYS__COM', nil)
     Bundler.with_unbundled_env do
       ENV['BUNDLE_GEMS__CONTRIBSYS__COM'] = contribsys_credentials
-      results << block.call(environment)
+      results << block.call(environment) unless repo.exclude_envs&.include?(environment)
 
       # Some of our apps use non-standard envs, which we deploy alongside prod
       if environment == 'prod' && repo.non_standard_envs


### PR DESCRIPTION
## Why was this change made?

This allows us to add dlme-airflow into our normal sde-deploy process.

## How was this change tested?



## Which documentation and/or configurations were updated?



