### PR TITLE
Add newest macos platform to Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,6 +86,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-23
+  arm64-darwin-24
   x86_64-darwin-19
   x86_64-darwin-20
   x86_64-darwin-21


### PR DESCRIPTION
## Why was this change made?

Small housekeeping PR so that this doesn't continue to show up for folks.


## How was this change tested?



## Which documentation and/or configurations were updated?



