### PR TITLE
Add a prompt to bin/sdr deploy and check_ssh to avoid forgetting abou…

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Options:
   -s, [--skip-update], [--no-skip-update]  # Skip update repos
   -e, --environment=ENVIRONMENT            # Environment (["qa", "prod", "stage"])
                                            # Possible values: qa, prod, stage
+  -c, [--control_master]                   # Skip the control master prompt
 
 check SSH connections
 
@@ -156,6 +157,7 @@ Options:
   -s, [--skip-update], [--no-skip-update]  # Skip update repos
   -e, --environment=ENVIRONMENT            # Deployment environment
                                            # Possible values: qa, prod, stage
+  -c, [--control_master]                   # Skip the control master prompt
 
 deploy all the services in an environment
 

--- a/bin/sdr
+++ b/bin/sdr
@@ -88,9 +88,20 @@ class CLI < Thor
          banner: 'ENVIRONMENT',
          desc: "Environment (#{Settings.supported_envs.keys.map(&:to_s)})",
          aliases: '-e'
+  option :control_master,
+         type: :boolean,
+         default: false,
+         desc: 'Use control master for SSH connections',
+         aliases: '-c'
   desc 'check_ssh', 'check SSH connections'
   def check_ssh
     raise Thor::Error, 'Use only one of --only or --except' if options[:only].any? && options[:except].any?
+
+    unless options[:control_master]
+      say("Checking SSH connections for #{options[:environment]} environment requires a control master.")
+      control_master = ask('Have you started a control master session: (y/n): ')
+      exit unless control_master.downcase == 'y'
+    end
 
     repositories = if options[:only].any?
                      Settings.repositories.select { |repo| options[:only].include?(repo.name) }
@@ -137,9 +148,20 @@ class CLI < Thor
          banner: 'ENVIRONMENT',
          desc: 'Deployment environment',
          aliases: '-e'
+  option :control_master,
+         type: :boolean,
+         default: false,
+         desc: 'Use control master for SSH connections',
+         aliases: '-c'
   desc 'deploy', 'deploy all the services in an environment'
   def deploy
     raise Thor::Error, 'Use only one of --only or --except' if options[:only].any? && options[:except].any?
+
+    unless options[:control_master]
+      say("Checking SSH connections for #{options[:environment]} environment requires a control master.")
+      control_master = ask('Have you started a control master session: (y/n): ')
+      exit unless control_master.downcase == 'y'
+    end
 
     repositories = if options[:cocina]
                      Settings.repositories.select(&:cocina_models_update)


### PR DESCRIPTION
…t the control master requirement

Note this does not verify if a control master is connected, as discussed, this first step simply prompts the user if they have connected to the control master and allows the application to pause while they do if necessary.

Also includes a command line option `-c, --control_master` if the individual user wants to bypass the question.

https://github.com/user-attachments/assets/2edc210d-98e7-4bb9-b77f-265980dba666


## Why was this change made?



## How was this change tested?



## Which documentation and/or configurations were updated?



