### PR TITLE
Verify control master is open for deploy and check_ssh

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Options:
   -s, [--skip-update], [--no-skip-update]  # Skip update repos
   -e, --environment=ENVIRONMENT            # Environment (["qa", "prod", "stage"])
                                            # Possible values: qa, prod, stage
+  -c, [--control_master]                   # Skip the control master prompt
 
 check SSH connections
 
@@ -156,6 +157,7 @@ Options:
   -s, [--skip-update], [--no-skip-update]  # Skip update repos
   -e, --environment=ENVIRONMENT            # Deployment environment
                                            # Possible values: qa, prod, stage
+  -c, [--control_master]                   # Skip the control master prompt
 
 deploy all the services in an environment
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Options:
   -s, [--skip-update], [--no-skip-update]  # Skip update repos
   -e, --environment=ENVIRONMENT            # Environment (["qa", "prod", "stage"])
                                            # Possible values: qa, prod, stage
-  -c, [--control_master]                   # Skip the control master prompt
+      [--skip_control_master]              # Skip the control master check
 
 check SSH connections
 
@@ -157,8 +157,7 @@ Options:
   -s, [--skip-update], [--no-skip-update]  # Skip update repos
   -e, --environment=ENVIRONMENT            # Deployment environment
                                            # Possible values: qa, prod, stage
-  -c, [--control_master]                   # Skip the control master prompt
-
+      [--skip_control_master]              # Skip the control master check
 deploy all the services in an environment
 
 Examples:

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Options:
   -s, [--skip-update], [--no-skip-update]  # Skip update repos
   -e, --environment=ENVIRONMENT            # Environment (["qa", "prod", "stage"])
                                            # Possible values: qa, prod, stage
-      [--skip_control_master]              # Skip the control master check
+      [--skip-control-master]    # Skip checking for active SSH control master connection
 
 check SSH connections
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Options:
   -s, [--skip-update], [--no-skip-update]  # Skip update repos
   -e, --environment=ENVIRONMENT            # Environment (["qa", "prod", "stage"])
                                            # Possible values: qa, prod, stage
-      [--skip-control-master]    # Skip checking for active SSH control master connection
+      [--skip-control-master]              # Skip checking for active SSH control master connection
 
 check SSH connections
 
@@ -157,7 +157,7 @@ Options:
   -s, [--skip-update], [--no-skip-update]  # Skip update repos
   -e, --environment=ENVIRONMENT            # Deployment environment
                                            # Possible values: qa, prod, stage
-      [--skip_control_master]              # Skip the control master check
+      [--skip-control-master]              # Skip checking for active SSH control master connection
 deploy all the services in an environment
 
 Examples:

--- a/bin/sdr
+++ b/bin/sdr
@@ -88,9 +88,20 @@ class CLI < Thor
          banner: 'ENVIRONMENT',
          desc: "Environment (#{Settings.supported_envs.keys.map(&:to_s)})",
          aliases: '-e'
+  option :control_master,
+         type: :boolean,
+         default: false,
+         desc: 'Use control master for SSH connections',
+         aliases: '-c'
   desc 'check_ssh', 'check SSH connections'
   def check_ssh
     raise Thor::Error, 'Use only one of --only or --except' if options[:only].any? && options[:except].any?
+
+    unless options[:control_master]
+      say("Checking SSH connections for #{options[:environment]} environment requires a control master.")
+      control_master = ask('Have you started a control master session: (y/n): ')
+      exit unless control_master.downcase == 'y'
+    end
 
     repositories = if options[:only].any?
                      Settings.repositories.select { |repo| options[:only].include?(repo.name) }
@@ -137,9 +148,20 @@ class CLI < Thor
          banner: 'ENVIRONMENT',
          desc: 'Deployment environment',
          aliases: '-e'
+  option :control_master,
+         type: :boolean,
+         default: false,
+         desc: 'Use control master for SSH connections',
+         aliases: '-c'
   desc 'deploy', 'deploy all the services in an environment'
   def deploy
     raise Thor::Error, 'Use only one of --only or --except' if options[:only].any? && options[:except].any?
+
+    unless options[:control_master]
+      say("Checking SSH connections for #{options[:environment]} environment requires a control master.")
+      control_master = ask('Have you started a control master session: (y/n): ')
+      exit unless control_master.downcase == 'y'
+    end
 
     repositories = if options[:cocina]
                      Settings.repositories.select(&:cocina_models_update)

--- a/bin/sdr
+++ b/bin/sdr
@@ -13,13 +13,8 @@ class CLI < Thor
 
   no_commands do
     def check_control_master(skip)
-      unless skip
-        say("Checking SSH connections for #{options[:environment]} environment requires a control master.")
-        control_master = ask('Have you started a control master session: (y/n): ')
-        exit unless control_master.downcase == 'y'
-      end
-
-      return if `ps aux` =~ /ControlMaster=yes/
+      return if skip
+      return if system("ssh -O check #{Settings.control_master_host}", err: File::NULL)
 
       say('Control master not detected. Please start a control master session.')
       exit
@@ -103,16 +98,15 @@ class CLI < Thor
          banner: 'ENVIRONMENT',
          desc: "Environment (#{Settings.supported_envs.keys.map(&:to_s)})",
          aliases: '-e'
-  option :control_master,
+  option :skip_control_master,
          type: :boolean,
          default: false,
-         desc: 'Use control master for SSH connections',
-         aliases: '-c'
+         desc: 'Skip checking for active SSH control master connection'
   desc 'check_ssh', 'check SSH connections'
   def check_ssh
     raise Thor::Error, 'Use only one of --only or --except' if options[:only].any? && options[:except].any?
 
-    check_control_master(options[:control_master])
+    check_control_master(options[:skip_control_master])
 
     repositories = if options[:only].any?
                      Settings.repositories.select { |repo| options[:only].include?(repo.name) }
@@ -159,16 +153,15 @@ class CLI < Thor
          banner: 'ENVIRONMENT',
          desc: 'Deployment environment',
          aliases: '-e'
-  option :control_master,
+  option :skip_control_master,
          type: :boolean,
          default: false,
-         desc: 'Use control master for SSH connections',
-         aliases: '-c'
+         desc: 'Skip checking for active SSH control master connection'
   desc 'deploy', 'deploy all the services in an environment'
   def deploy
     raise Thor::Error, 'Use only one of --only or --except' if options[:only].any? && options[:except].any?
 
-    check_control_master(options[:control_master])
+    check_control_master(options[:skip_control_master])
 
     repositories = if options[:cocina]
                      Settings.repositories.select(&:cocina_models_update)

--- a/bin/sdr
+++ b/bin/sdr
@@ -11,6 +11,21 @@ class CLI < Thor
     true
   end
 
+  no_commands do
+    def check_control_master(skip)
+      unless skip
+        say("Checking SSH connections for #{options[:environment]} environment requires a control master.")
+        control_master = ask('Have you started a control master session: (y/n): ')
+        exit unless control_master.downcase == 'y'
+      end
+
+      return if `ps aux` =~ /ControlMaster=yes/
+
+      say('Control master not detected. Please start a control master session.')
+      exit
+    end
+  end
+
   option :skip_update,
          type: :boolean,
          default: false,
@@ -97,11 +112,7 @@ class CLI < Thor
   def check_ssh
     raise Thor::Error, 'Use only one of --only or --except' if options[:only].any? && options[:except].any?
 
-    unless options[:control_master]
-      say("Checking SSH connections for #{options[:environment]} environment requires a control master.")
-      control_master = ask('Have you started a control master session: (y/n): ')
-      exit unless control_master.downcase == 'y'
-    end
+    check_control_master(options[:control_master])
 
     repositories = if options[:only].any?
                      Settings.repositories.select { |repo| options[:only].include?(repo.name) }
@@ -157,11 +168,7 @@ class CLI < Thor
   def deploy
     raise Thor::Error, 'Use only one of --only or --except' if options[:only].any? && options[:except].any?
 
-    unless options[:control_master]
-      say("Checking SSH connections for #{options[:environment]} environment requires a control master.")
-      control_master = ask('Have you started a control master session: (y/n): ')
-      exit unless control_master.downcase == 'y'
-    end
+    check_control_master(options[:control_master])
 
     repositories = if options[:cocina]
                      Settings.repositories.select(&:cocina_models_update)

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,3 +1,4 @@
+control_master_host: sdr-infra
 work_dir: tmp/repos
 light_mode: false
 num_parallel_processes: 4


### PR DESCRIPTION
## Why was this change made?

This should help avoid locking accounts out by verifying that a control master is established before running ssh commands.

Prompts the user to allow a pause for connecting a control master, and a `-c, --control_master` option to skip the prompt.

Uploading Screen Recording 2024-12-17 at 3.59.47 PM.mov…



## How was this change tested?



## Which documentation and/or configurations were updated?



