### PR TITLE
Add speech-to-text

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -44,6 +44,11 @@ repositories:
   - name: sul-dlss/robot-console
   - name: sul-dlss/sdr-api
     cocina_models_update: true
+  - name: sul-dlss/speech-to-text # deployment to AWS is handled by a Github Action
+    exclude_envs:
+      - prod
+      - stage
+      - qa
   - name: sul-dlss/sul_pub
     non_standard_envs:
       - uat


### PR DESCRIPTION
## Why was this change made?

We want to tag releases in sul-dlss/speech-to-text but there is nothing to deploy since a Github Action will deploy to AWS.

## How was this change tested?

It hasn't.

## Which documentation and/or configurations were updated?



