### PR TITLE
rialto-orgs does not have a qa environment

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -41,6 +41,8 @@ repositories:
   - name: sul-dlss/preservation_catalog
   - name: sul-dlss/preservation_robots
   - name: sul-dlss/rialto-orgs
+    exclude_envs:
+      - qa
   - name: sul-dlss/robot-console
   - name: sul-dlss/sdr-api
     cocina_models_update: true


### PR DESCRIPTION
## Why was this change made?



## How was this change tested?



## Which documentation and/or configurations were updated?



