### PR TITLE
Add audit_repos in order to run bundle audit against all SDR repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,18 @@ Options:
       [--except=one two three]             # Update all except these repos
 ```
 
+### Bundle audit all repos
+
+If you want to find the SDR repos effected by a CVE alert, `audit_repos` will run bundle audit on each repository to find each SDR repository that may be effected.
+
+```
+Usage:
+  bin/sdr audit_repos
+
+Note:
+  For non-rails repositories that do not execute bundle commands, you can add skip_audit: true to the repo config.
+```
+
 ### Notes and tips:
 * All repos will be cloned to `tmp/repos`.
 * Any repos cloned to `tmp/repos` that are removed from `config/settings.yml`, *e.g.* projects that have been decommissioned, will be automatically removed from `tmp/repos` the next time any of the sdr-deploy commands are run (unless the repo update is explicitly skipped via user-provided flag).

--- a/bin/sdr
+++ b/bin/sdr
@@ -202,6 +202,11 @@ class CLI < Thor
   def refresh_repos
     RepoUpdater.update(repos: Settings.repositories, prune: options.slice(:only, :except).none?)
   end
+
+  desc 'audit_repos', 'run bundle audit on local repos'
+  def audit_repos
+    RepoAuditor.audit(repos: Settings.repositories)
+  end
 end
 
 CLI.start(ARGV)

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -51,6 +51,7 @@ repositories:
       - prod
       - stage
       - qa
+    skip_audit: true
   - name: sul-dlss/sul_pub
     non_standard_envs:
       - uat

--- a/lib/repo_auditor.rb
+++ b/lib/repo_auditor.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# Service class for running bundle audit
+class RepoAuditor
+  def self.audit(repos:)
+    new(repos:).audit_repos
+  end
+
+  attr_reader :repos, :auditor
+
+  def initialize(repos:)
+    @repos = repos
+    @auditor = Auditor.new
+  end
+
+  def audit_repos
+    puts "repos to bundle audit: #{repos.map(&:name).join(', ')}"
+    Parallel.each(repos, in_processes: Settings.num_parallel_processes) do |repo|
+      within_project_dir(repo:) do
+        puts "running 'bundle audit' for #{repo.name}"
+        auditor.audit(repo: repo.name) unless repo.skip_audit
+      end
+    end
+
+    auditor.report
+  end
+end


### PR DESCRIPTION
## Why was this change made?

Small quality of life addition.


```
running 'bundle audit' for sul-dlss/dlme-airflow
running 'bundle audit' for sul-dlss/common-accessioning
running 'bundle audit' for sul-dlss/dor-services-app
running 'bundle audit' for sul-dlss/argo
running 'bundle audit' for sul-dlss/gis-robot-suite
running 'bundle audit' for sul-dlss/google-books
running 'bundle audit' for sul-dlss/happy-heron
running 'bundle audit' for sul-dlss/hungry-hungry-hippo
running 'bundle audit' for sul-dlss/hydra_etd
running 'bundle audit' for sul-dlss/modsulator-app-rails
running 'bundle audit' for sul-dlss/pre-assembly
running 'bundle audit' for sul-dlss/preservation_catalog
running 'bundle audit' for sul-dlss/preservation_robots
running 'bundle audit' for sul-dlss/rialto-orgs
running 'bundle audit' for sul-dlss/robot-console
running 'bundle audit' for sul-dlss/sdr-api
running 'bundle audit' for sul-dlss/speech-to-text
running 'bundle audit' for sul-dlss/sul_pub
running 'bundle audit' for sul-dlss/suri-rails
running 'bundle audit' for sul-dlss/technical-metadata-service
running 'bundle audit' for sul-dlss/was-pywb
running 'bundle audit' for sul-dlss/was-registrar-app
running 'bundle audit' for sul-dlss/was_robot_suite
running 'bundle audit' for sul-dlss/workflow-server-rails
◈─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────◈
Bundle Audit Security Report
No bundle security vulnerabilities found!
```
## How was this change tested?



## Which documentation and/or configurations were updated?



