### PR TITLE
Deploy heracles to etd-qa and -stage and hydra to -prod and -uat

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -36,8 +36,8 @@ repositories:
     # # TODO: once heracles can go to prod, it can go to uat, in which case we'd want to
     #         uncomment the following lines, remove the `exclude_envs` immediately above,
     #         and get rid of hydra_etd below.
-    # non_standard_envs:
-    #   - uat
+    non_standard_envs:
+      - uat
   - name: sul-dlss/hungry-hungry-hippo
     cocina_models_update: true
   - name: sul-dlss/hydra_etd
@@ -45,8 +45,6 @@ repositories:
     exclude_envs:
       - qa
       - stage
-    non_standard_envs:
-      - uat
   - name: sul-dlss/modsulator-app-rails
   - name: sul-dlss/pre-assembly
     cocina_models_update: true

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -33,8 +33,7 @@ repositories:
     cocina_models_update: true
     exclude_envs:
       - prod
-    # # TODO: once heracles can go to prod, it can go to uat, in which case we'd want to
-    #         uncomment the following lines, remove the `exclude_envs` immediately above,
+    # # TODO: once heracles can go to prod, remove the `exclude_envs` immediately above,
     #         and get rid of hydra_etd below.
     non_standard_envs:
       - uat

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -29,10 +29,22 @@ repositories:
     cocina_models_update: true
   - name: sul-dlss/happy-heron
     cocina_models_update: true
+  - name: sul-dlss/heracles-etd
+    cocina_models_update: true
+    exclude_envs:
+      - prod
+    # # TODO: once heracles can go to prod, it can go to uat, in which case we'd want to
+    #         uncomment the following lines, remove the `exclude_envs` immediately above,
+    #         and get rid of hydra_etd below.
+    # non_standard_envs:
+    #   - uat
   - name: sul-dlss/hungry-hungry-hippo
     cocina_models_update: true
   - name: sul-dlss/hydra_etd
     cocina_models_update: true
+    exclude_envs:
+      - qa
+      - stage
     non_standard_envs:
       - uat
   - name: sul-dlss/modsulator-app-rails
@@ -62,4 +74,3 @@ repositories:
     cocina_models_update: true
   - name: sul-dlss/was_robot_suite
     cocina_models_update: true
-  


### PR DESCRIPTION
We have an active work cycle where we're replacing hydra_etd (with heracles), and we need to carefully roll that out as we're ready.