### PR TITLE
Recover from failed/incomplete repo clones

### DIFF
--- a/lib/repo_updater.rb
+++ b/lib/repo_updater.rb
@@ -51,7 +51,10 @@ class RepoUpdater
   end
 
   def already_created?
-    File.exist?(repo_dir)
+    # Check for a real clone (.git), not just the directory: a failed clone can
+    # leave an empty dir behind, and treating that as "created" means we run
+    # update_repo (git fetch/reset) against the parent repo instead of re-cloning.
+    File.directory?(File.join(repo_dir, '.git'))
   end
 
   def update_or_create_repo
@@ -71,7 +74,7 @@ class RepoUpdater
       ErrorEmittingExecutor.execute('git fetch --tags origin', exit_on_error: true)
       ErrorEmittingExecutor.execute('git reset --hard $(git symbolic-ref refs/remotes/origin/HEAD)',
                                     exit_on_error: true)
-      ErrorEmittingExecutor.execute('bundle install')
+      ErrorEmittingExecutor.execute('bundle install', exit_on_error: true)
     end
   end
 
@@ -80,7 +83,7 @@ class RepoUpdater
     within_project_dir(repo:) do
       ErrorEmittingExecutor.execute("git clone --tags git@github.com:#{repo.name}.git .", exit_on_error: true)
       ErrorEmittingExecutor.execute('git fetch --tags origin', exit_on_error: true)
-      ErrorEmittingExecutor.execute('bundle install')
+      ErrorEmittingExecutor.execute('bundle install', exit_on_error: true)
     end
   end
 end


### PR DESCRIPTION
## Why was this change made?

A failed `git clone` can leave an empty directory behind in the repo
cache. `already_created?` only checked for the directory's existence, so
subsequent runs treated the empty dir as a valid clone and ran
`update_repo` (git fetch/reset) instead of re-cloning. With no `.git`
present, those git commands operate against the parent sdr-deploy repo
and never populate the dir, so it stays broken indefinitely.

Downstream, `bundle`/`cap` invoked in the empty dir walk up the tree to
sdr-deploy's Gemfile (which lacks capistrano), producing a confusing
"capistrano is not currently included in the bundle" error during
check_ssh/deploy.

- Check for a real clone (.git) in `already_created?` so a failed clone
  self-heals on the next run.
- Run `bundle install` with `exit_on_error: true` (matching the git
  commands) so install failures surface loudly instead of silently
  leaving an incomplete bundle.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

## How was this change tested?

I was having trouble with `bin/sdr check-ssh -e stage` since it was reporting
capistrano wasn't available for some repos. It turned out some of those repos
in tmp/ were empty for some reason. Claude recommended these changes to ensure
that failed clones surfaced. Perhaps this is just an issue with the fact that
I moved to mise which maybe caught it?

## Which documentation and/or configurations were updated?

n/a
